### PR TITLE
refactor: restructure to Anthropic skills format

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,24 +92,23 @@ Strong success criteria let the LLM loop independently. Weak criteria ("make it 
 
 ## Install
 
-**Option A: CLAUDE.md (recommended)**
+**Option A: Skills CLI (recommended)**
+
+```bash
+npx skills add forrestchang/andrej-karpathy-skills
+```
+
+**Option B: CLAUDE.md**
 
 New project:
 ```bash
-curl -o CLAUDE.md https://raw.githubusercontent.com/forrestchang/andrej-karpthy-skills/main/CLAUDE.md
+curl -o CLAUDE.md https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md
 ```
 
 Existing project (append):
 ```bash
 echo "" >> CLAUDE.md
-curl https://raw.githubusercontent.com/forrestchang/andrej-karpthy-skills/main/CLAUDE.md >> CLAUDE.md
-```
-
-**Option B: Skills directory**
-
-```bash
-mkdir -p .claude/skills
-curl -o .claude/skills/karpathy-guidelines.md https://raw.githubusercontent.com/forrestchang/andrej-karpthy-skills/main/.claude/skills/karpathy-guidelines.md
+curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
 ```
 
 ## Key Insight

--- a/skills/karpathy-guidelines/SKILL.md
+++ b/skills/karpathy-guidelines/SKILL.md
@@ -1,6 +1,12 @@
+---
+name: karpathy-guidelines
+description: Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, surface assumptions, and define verifiable success criteria.
+license: MIT
+---
+
 # Karpathy Guidelines
 
-Behavioral guidelines to reduce common LLM coding mistakes. Apply these principles to all coding tasks.
+Behavioral guidelines to reduce common LLM coding mistakes, derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.
 
 **Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
 


### PR DESCRIPTION
## Summary

- Restructures the repository to follow the [Anthropic skills format](https://github.com/anthropics/skills)
- Single `SKILL.md` file with frontmatter + content (no separate AGENTS.md, README.md, metadata.json)
- Adds skills CLI installation option (`npx skills add`)
- Fixes URL typo in README (`karpthy` -> `karpathy`)

## Changes

- `skills/karpathy-guidelines/SKILL.md` - Combined frontmatter + full content
- `README.md` - Added skills CLI install, fixed URLs

## Test plan

- [x] Verify skill can be installed via `npx skills add forrestchang/andrej-karpathy-skills`

🤖 Generated with [Claude Code](https://claude.com/claude-code)