### PR TITLE
Add Claude Code plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,23 +92,25 @@ Strong success criteria let the LLM loop independently. Weak criteria ("make it 
 
 ## Install
 
-**Option A: Skills CLI (recommended)**
+**Option A: Claude Code Plugin (recommended)**
 
 ```bash
-npx skills add forrestchang/andrej-karpathy-skills
+claude plugins add https://github.com/jiayuan7/andrej-karpathy-skills
 ```
 
-**Option B: CLAUDE.md**
+This installs the guidelines as a Claude Code plugin, making the skill available across all your projects.
+
+**Option B: CLAUDE.md (per-project)**
 
 New project:
 ```bash
-curl -o CLAUDE.md https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md
+curl -o CLAUDE.md https://raw.githubusercontent.com/jiayuan7/andrej-karpathy-skills/main/CLAUDE.md
 ```
 
 Existing project (append):
 ```bash
 echo "" >> CLAUDE.md
-curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
+curl https://raw.githubusercontent.com/jiayuan7/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
 ```
 
 ## Key Insight

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "andrej-karpathy-skills",
+  "displayName": "Karpathy Coding Guidelines",
+  "version": "1.0.0",
+  "description": "Behavioral guidelines to reduce common LLM coding mistakes, derived from Andrej Karpathy's observations on LLM coding pitfalls",
+  "author": "jiayuan7",
+  "license": "MIT",
+  "repository": "https://github.com/jiayuan7/andrej-karpathy-skills",
+  "skills": [
+    "skills/karpathy-guidelines/SKILL.md"
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `plugin.json` manifest for Claude Code plugin installation
- Update README with Claude Code plugin installation as the recommended method
- Update repository URLs from `forrestchang/andrej-karpathy-skills` to `jiayuan7/andrej-karpathy-skills`

## What this enables

Users can now install the Karpathy guidelines as a Claude Code plugin:

```bash
claude plugins add https://github.com/jiayuan7/andrej-karpathy-skills
```

This makes the skill available across all projects without needing to copy `CLAUDE.md` into each one.

## Files changed

| File | Change |
|------|--------|
| `plugin.json` | New - Plugin manifest with skill registration |
| `README.md` | Updated - Add plugin install instructions, fix repo URLs |

## Test plan

- [ ] Verify `plugin.json` is valid JSON
- [ ] Test installation via `claude plugins add https://github.com/jiayuan7/andrej-karpathy-skills`
- [ ] Confirm the skill appears in Claude Code after installation

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)