### PR TITLE
Fix GitHub repository links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Strong success criteria let the LLM loop independently. Weak criteria ("make it 
 **Option A: Claude Code Plugin (recommended)**
 
 ```bash
-claude plugins add https://github.com/jiayuan7/andrej-karpathy-skills
+claude plugins add https://github.com/forrestchang/andrej-karpathy-skills
 ```
 
 This installs the guidelines as a Claude Code plugin, making the skill available across all your projects.
@@ -104,13 +104,13 @@ This installs the guidelines as a Claude Code plugin, making the skill available
 
 New project:
 ```bash
-curl -o CLAUDE.md https://raw.githubusercontent.com/jiayuan7/andrej-karpathy-skills/main/CLAUDE.md
+curl -o CLAUDE.md https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md
 ```
 
 Existing project (append):
 ```bash
 echo "" >> CLAUDE.md
-curl https://raw.githubusercontent.com/jiayuan7/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
+curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
 ```
 
 ## Key Insight


### PR DESCRIPTION
## Summary

Updated all references in the README from the old repository (jiayuan7/andrej-karpathy-skills) to the correct repository location (forrestchang/andrej-karpathy-skills). This ensures installation instructions point users to the correct GitHub repository.

## Changes

- Updated plugin installation URL
- Updated curl commands for both new and existing project setup

🤖 Generated with Claude Code