### PR TITLE
Fix plugin structure for Claude Code compatibility

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,9 +3,9 @@
   "displayName": "Karpathy Coding Guidelines",
   "version": "1.0.0",
   "description": "Behavioral guidelines to reduce common LLM coding mistakes, derived from Andrej Karpathy's observations on LLM coding pitfalls",
-  "author": "jiayuan7",
+  "author": "forrestchang",
   "license": "MIT",
-  "repository": "https://github.com/jiayuan7/andrej-karpathy-skills",
+  "repository": "https://github.com/forrestchang/andrej-karpathy-skills",
   "skills": [
     "skills/karpathy-guidelines/SKILL.md"
   ]


### PR DESCRIPTION
## Summary

- Move `plugin.json` to `.claude-plugin/plugin.json` as required by the Claude Code plugin specification
- Fix author and repository URL to point to correct owner (forrestchang)

## Problem

The current plugin structure has `plugin.json` at the repository root, but Claude Code requires the manifest to be located at `.claude-plugin/plugin.json` for proper plugin discovery and loading.

This causes `claude plugins add https://github.com/forrestchang/andrej-karpathy-skills` to fail.

## Reference

From the [Claude Code plugin specification](https://docs.anthropic.com/en/docs/claude-code/plugins):
> The plugin.json manifest MUST be in .claude-plugin/ directory

## Test plan

- [ ] Run `claude plugins add https://github.com/forrestchang/andrej-karpathy-skills` after merge
- [ ] Verify the karpathy-guidelines skill loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)