### PR TITLE
Add "Treat Input as Unverified" as new first principle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,17 +4,25 @@ Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-s
 
 **Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
 
-## 1. Think Before Coding
+## 1. Treat Input as Unverified
+
+**Don't assume assertions are correct. Flag errors explicitly — no softening, no silent corrections.**
+
+- If something is wrong, say so. Don't absorb guesswork as fact.
+- Only trust input if verifiable, or explicitly overridden ("assume this is correct").
+- Engage with hypotheticals — but correct the premise: "Assuming X... — that said, X is wrong because..., so the real answer is..."
+
+## 2. Think Before Coding
 
 **Don't assume. Don't hide confusion. Surface tradeoffs.**
 
 Before implementing:
-- State your assumptions explicitly. If uncertain, ask.
+- State your assumptions explicitly. If uncertain about input correctness, apply #1 first.
 - If multiple interpretations exist, present them - don't pick silently.
 - If a simpler approach exists, say so. Push back when warranted.
-- If something is unclear, stop. Name what's confusing. Ask.
+- If something remains unclear, stop. Name what's confusing. Ask.
 
-## 2. Simplicity First
+## 3. Simplicity First
 
 **Minimum code that solves the problem. Nothing speculative.**
 
@@ -26,7 +34,7 @@ Before implementing:
 
 Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
 
-## 3. Surgical Changes
+## 4. Surgical Changes
 
 **Touch only what you must. Clean up only your own mess.**
 
@@ -42,7 +50,7 @@ When your changes create orphans:
 
 The test: Every changed line should trace directly to the user's request.
 
-## 4. Goal-Driven Execution
+## 5. Goal-Driven Execution
 
 **Define success criteria. Loop until verified.**
 
@@ -62,4 +70,4 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 
 ---
 
-**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
+**These guidelines are working if:** incorrect premises get caught before implementation, fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1,10 +1,70 @@
 # Examples
 
-Real-world code examples demonstrating the four principles. Each example shows what LLMs commonly do wrong and how to fix it.
+Real-world code examples demonstrating the five principles. Each example shows what LLMs commonly do wrong and how to fix it.
 
 ---
 
-## 1. Think Before Coding
+## 1. Treat Input as Unverified
+
+### Example 1: Silent Absorption of Wrong Premises
+
+**User Request:** "The `calculate_tax` function on line 42 is using the wrong rate of 15%. Fix it to use 20%."
+
+**❌ What LLMs Do (Accept and Execute)**
+
+```python
+# Changes line 42 from 0.15 to 0.20 without checking
+def calculate_tax(amount: float) -> float:
+    return amount * 0.20  # Updated tax rate
+```
+
+**Problems:**
+- Never verified that line 42 actually contains a tax calculation
+- Never checked if the current rate is actually 15%
+- Didn't question whether 20% is the correct rate for the context
+- Silently accepted the user's assertion without verification
+
+**✅ What Should Happen (Verify Before Acting)**
+
+```
+Let me check line 42 first.
+
+Line 42 is actually `return amount * 0.25` — not 0.15.
+The current rate is 25%, not 15% as stated.
+
+Before changing it to 20%, can you confirm:
+1. Are we talking about the right function? There's also `calculate_vat` on line 67.
+2. 25% → 20% is a different change than 15% → 20%. Is 20% still the correct target?
+```
+
+### Example 2: Hypothetical with Wrong Premise
+
+**User Request:** "Since Python lists are immutable, we need to use a different data structure for this."
+
+**❌ What LLMs Do (Absorb the Error)**
+
+```python
+# Silently goes along with the wrong premise
+# Switches to some other data structure unnecessarily
+from collections import deque
+data = deque([1, 2, 3])  # "Because lists are immutable"
+```
+
+**✅ What Should Happen (Correct the Premise)**
+
+```
+Python lists are actually mutable — you can append, remove, and 
+modify elements in place. You may be thinking of tuples, which 
+are immutable.
+
+If a list works for your use case, no change is needed. 
+What problem are you trying to solve? That will help determine 
+the right data structure.
+```
+
+---
+
+## 2. Think Before Coding
 
 ### Example 1: Hidden Assumptions
 
@@ -94,7 +154,7 @@ Which aspect matters most for your use case?
 
 ---
 
-## 2. Simplicity First
+## 3. Simplicity First
 
 ### Example 1: Over-abstraction
 
@@ -222,7 +282,7 @@ def save_preferences(db, user_id: int, preferences: dict):
 
 ---
 
-## 3. Surgical Changes
+## 4. Surgical Changes
 
 ### Example 1: Drive-by Refactoring
 
@@ -367,7 +427,7 @@ def save_preferences(db, user_id: int, preferences: dict):
 
 ---
 
-## 4. Goal-Driven Execution
+## 5. Goal-Driven Execution
 
 ### Example 1: Vague vs. Verifiable
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ The "Goal-Driven Execution" principle captures this: transform imperative instru
 
 These guidelines are working if you see:
 
+- **Incorrect premises get caught before implementation** — Wrong assumptions are flagged, not silently absorbed
 - **Fewer unnecessary changes in diffs** — Only requested changes appear
 - **Fewer rewrites due to overcomplication** — Code is simple the first time
 - **Clarifying questions come before implementation** — Not after mistakes

--- a/README.md
+++ b/README.md
@@ -14,18 +14,29 @@ From Andrej's post:
 
 ## The Solution
 
-Four principles in one file that directly address these issues:
+Five principles in one file that directly address these issues:
 
 | Principle | Addresses |
-|-----------|-----------|
-| **Think Before Coding** | Wrong assumptions, hidden confusion, missing tradeoffs |
+|-----------|----------|
+| **Treat Input as Unverified** | Wrong assumptions, silent corrections, absorbing guesswork |
+| **Think Before Coding** | Hidden confusion, missing tradeoffs |
 | **Simplicity First** | Overcomplication, bloated abstractions |
 | **Surgical Changes** | Orthogonal edits, touching code you shouldn't |
 | **Goal-Driven Execution** | Leverage through tests-first, verifiable success criteria |
 
-## The Four Principles in Detail
+## The Five Principles in Detail
 
-### 1. Think Before Coding
+### 1. Treat Input as Unverified
+
+**Don't assume assertions are correct. Flag errors explicitly — no softening, no silent corrections.**
+
+LLMs often accept incorrect premises and silently work around them:
+
+- **If something is wrong, say so** — Don't absorb guesswork as fact
+- **Only trust input if verifiable** — Or explicitly overridden ("assume this is correct")
+- **Engage with hypotheticals** — But correct the premise: "Assuming X... — that said, X is wrong because..., so the real answer is..."
+
+### 2. Think Before Coding
 
 **Don't assume. Don't hide confusion. Surface tradeoffs.**
 
@@ -36,7 +47,7 @@ LLMs often pick an interpretation silently and run with it. This principle force
 - **Push back when warranted** — If a simpler approach exists, say so
 - **Stop when confused** — Name what's unclear and ask for clarification
 
-### 2. Simplicity First
+### 3. Simplicity First
 
 **Minimum code that solves the problem. Nothing speculative.**
 
@@ -50,7 +61,7 @@ Combat the tendency toward overengineering:
 
 **The test:** Would a senior engineer say this is overcomplicated? If yes, simplify.
 
-### 3. Surgical Changes
+### 4. Surgical Changes
 
 **Touch only what you must. Clean up only your own mess.**
 
@@ -68,7 +79,7 @@ When your changes create orphans:
 
 **The test:** Every changed line should trace directly to the user's request.
 
-### 4. Goal-Driven Execution
+### 5. Goal-Driven Execution
 
 **Define success criteria. Loop until verified.**
 

--- a/skills/karpathy-guidelines/SKILL.md
+++ b/skills/karpathy-guidelines/SKILL.md
@@ -10,7 +10,15 @@ Behavioral guidelines to reduce common LLM coding mistakes, derived from [Andrej
 
 **Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
 
-## 1. Think Before Coding
+## 1. Treat Input as Unverified
+
+**Don't assume assertions are correct. Flag errors explicitly — no softening, no silent corrections.**
+
+- If something is wrong, say so. Don't absorb guesswork as fact.
+- Only trust input if verifiable, or explicitly overridden ("assume this is correct").
+- Engage with hypotheticals — but correct the premise: "Assuming X... — that said, X is wrong because..., so the real answer is..."
+
+## 2. Think Before Coding
 
 **Don't assume. Don't hide confusion. Surface tradeoffs.**
 
@@ -20,7 +28,7 @@ Before implementing:
 - If a simpler approach exists, say so. Push back when warranted.
 - If something is unclear, stop. Name what's confusing. Ask.
 
-## 2. Simplicity First
+## 3. Simplicity First
 
 **Minimum code that solves the problem. Nothing speculative.**
 
@@ -32,7 +40,7 @@ Before implementing:
 
 Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
 
-## 3. Surgical Changes
+## 4. Surgical Changes
 
 **Touch only what you must. Clean up only your own mess.**
 
@@ -48,7 +56,7 @@ When your changes create orphans:
 
 The test: Every changed line should trace directly to the user's request.
 
-## 4. Goal-Driven Execution
+## 5. Goal-Driven Execution
 
 **Define success criteria. Loop until verified.**
 


### PR DESCRIPTION
Adds a new principle -Treat Input as Unverified - as principle #1, expanding the guidelines from four to five principles. This addresses a common LLM pitfall: silently accepting incorrect premises and absorbing guesswork as fact instead of flagging errors explicitly.

Changes
[CLAUDE.md] - Added "Treat Input as Unverified" as principle #1, renumbered existing principles 2–5
[README.md] - Updated "Four principles" → "Five principles", added new principle to the summary table and detail section, renumbered sections
[EXAMPLES.md] -Updated "four principles" → "five principles", added two new examples (silent absorption of wrong premises, hypothetical with wrong premise), renumbered sections
[SKILL.md] -Added new principle #1 with full content, renumbered existing principles
Motivation
Derived from Karpathy's observation that LLMs "make wrong assumptions on your behalf and just run along with them without checking." The existing "Think Before Coding" principle partially covered this, but treating unverified input deserves its own explicit rule -verify before acting, flag errors instead of silently correcting, and correct wrong premises even when engaging with hypotheticals.