### PR TITLE
Add guideline 5: Documents over Documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,20 @@ For multi-step tasks, state a brief plan:
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
+## 5. Documents over Documentation
+
+**One document, one truth. No meta-docs.**
+
+Don't create documents to explain other documents. Edit the source instead.
+
+- Summary of existing doc? → Add a "Summary" section at the top of the existing doc.
+- Explanation of changes? → Edit the original with inline context.
+- Alternative options? → Archive in a `research/` subfolder, not the main directory.
+- Questions & answers? → Edit the spec directly; clarify in place.
+- Process artifacts? → Delete after the task completes; don't archive as "record-keeping".
+
+Ask yourself: "Does this document exist ONLY to explain or summarize another document?" If yes, delete it and fix the original instead.
+
 ---
 
 **These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/skills/karpathy-guidelines/SKILL.md
+++ b/skills/karpathy-guidelines/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: karpathy-guidelines
-description: Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, surface assumptions, and define verifiable success criteria.
+description: Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, surface assumptions, define verifiable success criteria, and prevent document sprawl.
 license: MIT
 ---
 
@@ -65,3 +65,17 @@ For multi-step tasks, state a brief plan:
 ```
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+## 5. Documents over Documentation
+
+**One document, one truth. No meta-docs.**
+
+Don't create documents to explain other documents. Edit the source instead.
+
+- Summary of existing doc? → Add a "Summary" section at the top of the existing doc.
+- Explanation of changes? → Edit the original with inline context.
+- Alternative options? → Archive in a `research/` subfolder, not the main directory.
+- Questions & answers? → Edit the spec directly; clarify in place.
+- Process artifacts? → Delete after the task completes; don't archive as "record-keeping".
+
+Ask yourself: "Does this document exist ONLY to explain or summarize another document?" If yes, delete it and fix the original instead.


### PR DESCRIPTION
## Summary
- Adds a 5th guideline "Documents over Documentation" to both `CLAUDE.md` and `skills/karpathy-guidelines/SKILL.md`
- Addresses LLM tendency to create meta-documents (summaries of summaries, explanation docs) instead of editing source documents directly
- Updates the SKILL.md frontmatter description to mention the new guideline

Closes #10

## Context
This guideline was proposed by @rkaramc in #10, based on observed LLM behavior of creating document sprawl — multiple overlapping docs like `SUMMARY.md` + `DECISION.md` + `PLAN.md` that erode trust and create confusion about which source is authoritative.

The core rule: if a document exists only to explain or summarize another document, delete it and fix the original instead.