### PR TITLE
feat: add "Communicate Progress" as 5th principle in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,26 @@ For multi-step tasks, state a brief plan:
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
+## 5. Communicate Progress
+
+**Narrate what you are doing, not what you did.**
+
+For multi-step tasks:
+- Announce the current step *before* starting it, not after.
+- Confirm completion of each step in one line.
+- Flag unexpected findings immediately — don't silently adapt and continue.
+
+```
+Step 1/3: Adding validation to src/auth.ts → verify: function accepts empty input
+✓ Done. Step 2/3: Writing failing test → verify: test fails before fix
+✓ Done. Step 3/3: Making test pass → verify: test suite green
+```
+
+Bad: Silently editing 12 files, then a final summary.
+Good: One line before and after each step so the user can interrupt if the plan is wrong.
+
+Keep narration minimal — one line per step is enough. No essays.
+
 ---
 
 **These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.


### PR DESCRIPTION
Closes #32

## Summary

Adds a **5th principle** — "Communicate Progress" — to `CLAUDE.md`.

## Problem

The existing four principles address *what* to do and *how* to structure work, but not *how to keep users informed during execution*. LLMs frequently run multi-step tasks silently, leaving users unable to catch plan deviations until significant work has been done incorrectly.

## Change

Added a new `## 5. Communicate Progress` section after "Goal-Driven Execution":

- Instructs LLMs to announce each step **before** starting, not after
- A one-line completion confirmation per step
- Immediate flagging of unexpected findings

## Why It Fits

This principle directly complements "Goal-Driven Execution": goal-driven defines *success criteria*, while communicate progress makes *execution observable*. Together they close the loop — define goals upfront, then narrate execution so users can intervene early.

The format is consistent with the existing sections: bold rule, bullet guidelines, code example, bad/good contrast.