### PR TITLE
fix: add missing closing code fence in EXAMPLES.md before Anti-Patterns Summary

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -495,6 +495,8 @@ def sort_scores(scores):
 
 ---
 
+```
+
 ## Anti-Patterns Summary
 
 | Principle | Anti-Pattern | Fix |


### PR DESCRIPTION
Closes #34

## Problem
The Multi-Step with Verification example opens a code block that is never closed before the Anti-Patterns Summary section, causing the table to render inside the code block.

## Fix  
Added the missing closing triple-backtick fence before the Anti-Patterns Summary section.