### PR TITLE
feat: add GitHub Copilot workspace instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,50 @@
+# GitHub Copilot Workspace Instructions
+
+These guidelines reduce common LLM coding mistakes in this repository.
+Apply them with project-specific instructions as needed.
+
+Tradeoff: these guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+Don't assume. Don't hide confusion. Surface tradeoffs.
+
+- State assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them; don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop, name what's confusing, and ask.
+
+## 2. Simplicity First
+
+Minimum code that solves the problem. Nothing speculative.
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask: would a senior engineer say this is overcomplicated? If yes, simplify.
+
+## 3. Surgical Changes
+
+Touch only what you must. Clean up only your own mess.
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it; don't delete it.
+- Remove imports/variables/functions your changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+Test: every changed line should trace directly to the request.
+
+## 4. Goal-Driven Execution
+
+Define success criteria. Loop until verified.
+
+- "Add validation" -> "Write tests for invalid inputs, then make them pass."
+- "Fix the bug" -> "Write a test that reproduces it, then make it pass."
+- "Refactor X" -> "Ensure tests pass before and after."
+
+For multi-step tasks, state a brief plan with a verification check per step.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ echo "" >> CLAUDE.md
 curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
 ```
 
+**Option C: GitHub Copilot (workspace instructions)**
+
+The repo includes `.github/copilot-instructions.md` for GitHub Copilot users. Copy it to your project:
+
+```bash
+mkdir -p .github
+curl -o .github/copilot-instructions.md https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/.github/copilot-instructions.md
+```
+
 ## Key Insight
 
 From Andrej:


### PR DESCRIPTION
Adds `.github/copilot-instructions.md` so GitHub Copilot users get the same 4 Karpathy principles that Claude Code users get from `CLAUDE.md`.

Copilot reads `.github/copilot-instructions.md` as workspace-level instructions. The file contains the same Think Before Coding, Simplicity First, Surgical Changes, and Goal-Driven Execution principles, adapted for Copilot's format.

Also adds Option C to the README install section with a curl command for copying the file.

No existing files were modified besides README.md (new section appended after Option B).

Relates to #12

This contribution was developed with AI assistance (Codex).