### PR TITLE
fix: clarify working Claude plugin install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,17 +94,23 @@ Strong success criteria let the LLM loop independently. Weak criteria ("make it 
 
 **Option A: Claude Code Plugin (recommended)**
 
-From within Claude Code, first add the marketplace:
+From within Claude Code chat:
 ```
 /plugin marketplace add forrestchang/andrej-karpathy-skills
-```
-
-Then install the plugin:
-```
 /plugin install andrej-karpathy-skills@karpathy-skills
 ```
 
+From terminal (CLI equivalent):
+```bash
+claude plugin marketplace add forrestchang/andrej-karpathy-skills
+claude plugin install andrej-karpathy-skills@karpathy-skills
+```
+
 This installs the guidelines as a Claude Code plugin, making the skill available across all your projects.
+
+Compatibility note:
+- If you see `claude plugins add` (plural) in older examples, that command is deprecated and does not work on current Claude Code builds.
+- Use `claude plugin ...` (singular) in terminal or `/plugin ...` in Claude Code chat.
 
 **Option B: CLAUDE.md (per-project)**
 

--- a/tests/test_install_commands.py
+++ b/tests/test_install_commands.py
@@ -1,0 +1,39 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+README = ROOT / "README.md"
+
+
+class InstallCommandDocsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.readme_text = README.read_text(encoding="utf-8")
+
+    def test_has_current_slash_plugin_commands(self) -> None:
+        self.assertIn(
+            "/plugin marketplace add forrestchang/andrej-karpathy-skills",
+            self.readme_text,
+        )
+        self.assertIn(
+            "/plugin install andrej-karpathy-skills@karpathy-skills",
+            self.readme_text,
+        )
+
+    def test_has_current_cli_plugin_commands(self) -> None:
+        self.assertIn(
+            "claude plugin marketplace add forrestchang/andrej-karpathy-skills",
+            self.readme_text,
+        )
+        self.assertIn(
+            "claude plugin install andrej-karpathy-skills@karpathy-skills",
+            self.readme_text,
+        )
+
+    def test_mentions_deprecated_plural_command(self) -> None:
+        self.assertIn("`claude plugins add`", self.readme_text)
+        self.assertIn("deprecated", self.readme_text.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Fixes confusion in plugin installation docs by clarifying the currently working Claude Code command forms and explicitly marking the deprecated command.

Closes #22
Closes #23

### What changed
- Updated `README.md` Option A install instructions to include:
  - Claude Code chat commands (`/plugin ...`)
  - Terminal CLI equivalents (`claude plugin ...`)
- Added compatibility note explaining that `claude plugins add` (plural) is deprecated on current builds.
- Added regression test `tests/test_install_commands.py` to ensure these command forms stay present and the deprecation note is not accidentally removed.

## Validation
- `python -m unittest tests.test_install_commands -v` (3 tests passing)

## Why this helps
Users reporting #22/#23 were blocked by outdated command syntax. This update makes the install path explicit and version-compatible in one place.