### PR TITLE
Add Multica as an install option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ echo "" >> CLAUDE.md
 curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
 ```
 
+**Option C: [Multica](https://github.com/multica-ai/multica) (managed agents platform)**
+
+This skill is available on [Multica](https://github.com/multica-ai/multica) — an open-source platform that turns coding agents into real teammates. Install the skill through Multica's skill management to share it across your entire team.
+
 ## Key Insight
 
 From Andrej:


### PR DESCRIPTION
## Summary
- Add Option C in the Install section linking to [Multica](https://github.com/multica-ai/multica) as an alternative way to use this skill through a managed agents platform.

## Test plan
- [ ] Verify the README renders correctly on GitHub
- [ ] Verify the Multica link points to the correct repo