### PR TITLE
Add principle 5: Machine-Verified Completeness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,21 @@ For multi-step tasks, state a brief plan:
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
+## 5. Machine-Verified Completeness
+
+**"Looks right" is not done. Passing gates are done.**
+
+After every non-trivial change:
+- Run your project's lint and type-check. Both must pass before claiming "fixed"
+- For multi-step tasks, declare success criteria upfront — not just a plan, but what passing looks like:
+  ```
+  1. [Step] → verify: [specific check, not "test it"]
+  2. [Step] → verify: [specific check]
+  ```
+- Declare gaps explicitly before saying "done": what was verified by automation vs. what requires runtime/browser testing
+
+The test: "Build passes" ≠ "done". Only verified execution of the user's actual scenario is done.
+
 ---
 
-**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, clarifying questions come before implementation rather than after mistakes, and "fixed" means a gate passed — not a gut feeling.


### PR DESCRIPTION
## What this adds

A fifth principle: **Machine-Verified Completeness** — the enforcement layer missing from the four behavioral principles.

Karpathy's principles fix *behavior*. This fixes *verification*: how do you actually confirm the AI did what it said?

## The principle

```
## 5. Machine-Verified Completeness

**"Looks right" is not done. Passing gates are done.**

After every non-trivial change:
- Run your project's lint and type-check. Both must pass before claiming "fixed"
- For multi-step tasks, declare success criteria upfront — not just a plan, but what passing looks like
- Declare gaps explicitly before saying "done": what was verified by automation vs. what requires runtime/browser testing

The test: "Build passes" ≠ "done". Only verified execution of the user's actual scenario is done.
```

## Why it belongs here

The four principles address what the LLM *does*. This addresses what it *claims*. Without it, the model can follow all four principles perfectly and still deliver unverified work — the most common failure mode when shipping real product.

Also updated the trailing "working if" line to include the machine verification signal.

---

Derived from shipping a real product with Claude Code as a co-engineer.