### PR TITLE
fix: add missing MIT license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 forrestchang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tests/check-license.sh
+++ b/tests/check-license.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -eu
+
+ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+LICENSE_FILE="$ROOT/LICENSE"
+
+if [ ! -f "$LICENSE_FILE" ]; then
+  echo "Missing LICENSE file at repo root" >&2
+  exit 1
+fi
+
+require_contains() {
+  needle="$1"
+  if ! grep -Fq "$needle" "$LICENSE_FILE"; then
+    echo "LICENSE file missing expected text: $needle" >&2
+    exit 1
+  fi
+}
+
+require_contains "MIT License"
+require_contains "Permission is hereby granted, free of charge, to any person obtaining a copy"
+require_contains "THE SOFTWARE IS PROVIDED \"AS IS\""
+
+echo "Root MIT LICENSE file is present and contains the expected text."


### PR DESCRIPTION
## Summary

Add the missing root MIT `LICENSE` file so the repository’s stated license is explicit and detectable.

## Reproduction

The repository already stated `MIT` in the README, plugin metadata, and skill metadata, but there was no root `LICENSE` file for GitHub/license scanners to detect.

## Patch Summary

- add a standard MIT `LICENSE` file at the repository root
- add a small shell contract test that ensures the root license file exists and contains expected MIT text

## Risks

Low. This is a repository metadata/legal consistency fix only.

## Validation

- `cd worktrees/forrestchang__andrej-karpathy-skills/issue-46 && tests/check-license.sh`
