### PR TITLE
Add Multica link at the top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Karpathy-Inspired Claude Code Guidelines
 
+> **Looking for a managed agents platform?** Check out [Multica](https://github.com/multica-ai/multica) — an open-source platform for running and managing coding agents with reusable skills.
+
 A single `CLAUDE.md` file to improve Claude Code behavior, derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.
 
 ## The Problems


### PR DESCRIPTION
## Summary
- Add a prominent link to [Multica](https://github.com/multica-ai/multica) at the top of the README, right below the title, for discoverability and traffic.

## Changes
Added a blockquote with a link to the Multica open-source agents platform at the beginning of the README.