### PR TITLE
feat: enforcement hooks for all 4 Karpathy principles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,3 +63,22 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 ---
 
 **These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
+
+---
+
+## Enforcement Hooks
+
+These guidelines are backed by lightweight Claude Code hooks that
+surface warnings when principles are at risk of being violated:
+
+- **PreToolUse** (`think-before-coding.mjs`) — warns when writing
+  200+ lines in a single tool call (Principle 2: Simplicity First).
+- **PostToolUse** (`surgical-changes.mjs`) — warns on suppression
+  markers (`eslint-disable`, `@ts-ignore`), formatting-only changes,
+  and comment removal (Principle 3: Surgical Changes).
+- **Stop** (`goal-driven-stop.mjs`) — surfaces a verification
+  checklist before task close (Principle 4: Goal-Driven Execution).
+
+The hooks are **advisory by default** — they warn but don't block.
+This matches the "bias toward caution over speed" philosophy while
+letting the agent exercise judgment on trivial tasks.

--- a/hooks/goal-driven-stop.mjs
+++ b/hooks/goal-driven-stop.mjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+// goal-driven-stop.mjs — Stop hook
+// Principle 4: "Define success criteria. Loop until verified."
+
+async function main() {
+  process.stdout.write(
+    `Karpathy Principle 4 — Goal-Driven Execution\n` +
+    `Before closing, verify:\n` +
+    `  - Success criteria were stated before implementation\n` +
+    `  - Each change traces to the user's request\n` +
+    `  - No speculative features were added\n` +
+    `  - Tests pass (if applicable)\n`
+  );
+  process.exit(0); // Don't block — advisory only
+}
+
+main().catch(() => process.exit(0));

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://code.claude.com/schemas/hooks.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/think-before-coding.mjs",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/surgical-changes.mjs",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/goal-driven-stop.mjs",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/surgical-changes.mjs
+++ b/hooks/surgical-changes.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// surgical-changes.mjs — PostToolUse hook
+// Principle 3: "Touch only what you must. Clean up only your own mess."
+
+/** Patterns that suppress linting/type tools — shortcuts that hide problems. */
+const SUPPRESSION_PATTERNS = [
+  /eslint-disable/,
+  /@ts-ignore/,
+  /#\s*nosec/,
+  /\/\/\s*nolint/,
+  /#\s*type:\s*ignore/,
+  /#\s*noqa/,
+];
+
+/**
+ * Returns true if the two strings differ only in whitespace.
+ * @param {string} a
+ * @param {string} b
+ * @returns {boolean}
+ */
+function isWhitespaceOnlyDiff(a, b) {
+  return a.replace(/\s+/g, "") === b.replace(/\s+/g, "");
+}
+
+/**
+ * Extracts comment lines from a block of text.
+ * Matches lines whose first non-whitespace token is //, #, or /**.
+ * @param {string} text
+ * @returns {string[]}
+ */
+function extractCommentLines(text) {
+  return text.split("\n").filter((line) => /^\s*(\/\/|#|\/\*)/.test(line));
+}
+
+async function main() {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  const raw = Buffer.concat(chunks).toString("utf8").trim();
+  if (!raw) process.exit(0);
+
+  let payload;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    process.exit(0);
+  }
+
+  const toolInput = payload.tool_input || {};
+  const oldString = toolInput.old_string || "";
+  const newString = toolInput.new_string || toolInput.content || "";
+
+  const warnings = [];
+
+  // Check 1: Suppression markers in the new content.
+  if (newString) {
+    for (const pattern of SUPPRESSION_PATTERNS) {
+      if (pattern.test(newString)) {
+        warnings.push(
+          `Warning: Karpathy Principle 3 — Surgical Changes\n` +
+          `New content contains a suppression marker matching /${pattern.source}/.\n` +
+          `Suppression markers hide problems rather than fixing them.\n` +
+          `Consider addressing the root cause instead.`
+        );
+        break; // One warning per file is enough
+      }
+    }
+  }
+
+  // Check 2: Formatting-only changes (only relevant when old_string is present).
+  if (oldString && newString) {
+    if (isWhitespaceOnlyDiff(oldString, newString)) {
+      warnings.push(
+        `Warning: Karpathy Principle 3 — Surgical Changes\n` +
+        `This edit changes only whitespace/formatting.\n` +
+        `"Match existing style, even if you'd do it differently."\n` +
+        `Verify this change was actually requested.`
+      );
+    }
+
+    // Check 3: Comment removal.
+    const oldComments = extractCommentLines(oldString);
+    const newComments = new Set(extractCommentLines(newString));
+    const removedComments = oldComments.filter((line) => !newComments.has(line));
+
+    if (removedComments.length > 0) {
+      warnings.push(
+        `Warning: Karpathy Principle 3 — Surgical Changes\n` +
+        `${removedComments.length} comment line(s) from the original were removed.\n` +
+        `"Don't improve adjacent comments unless that was part of the task."\n` +
+        `Removed:\n` +
+        removedComments.map((l) => `  ${l.trim()}`).join("\n")
+      );
+    }
+  }
+
+  if (warnings.length > 0) {
+    process.stderr.write(warnings.join("\n\n") + "\n");
+  }
+
+  // Advisory only — never block.
+  process.exit(0);
+}
+
+main().catch(() => process.exit(0));

--- a/hooks/think-before-coding.mjs
+++ b/hooks/think-before-coding.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// think-before-coding.mjs — PreToolUse hook
+// Principle 1: "Don't assume. Don't hide confusion."
+// Principle 2: "If you write 200 lines and it could be 50, rewrite it."
+
+const COMPLEXITY_THRESHOLD = 200; // lines
+
+async function main() {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  const raw = Buffer.concat(chunks).toString("utf8").trim();
+  if (!raw) process.exit(0);
+
+  let payload;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    process.exit(0);
+  }
+
+  const toolInput = payload.tool_input || {};
+  const content = toolInput.content || toolInput.new_string || "";
+
+  if (!content) process.exit(0);
+
+  const lineCount = content.split("\n").length;
+
+  if (lineCount > COMPLEXITY_THRESHOLD) {
+    process.stderr.write(
+      `Warning: Karpathy Principle 2 — Simplicity First\n` +
+      `You're about to write ${lineCount} lines. Could this be simpler?\n` +
+      `"If you write 200 lines and it could be 50, rewrite it."\n`
+    );
+    // Warn but don't block — exit 0
+  }
+
+  process.exit(0);
+}
+
+main().catch(() => process.exit(0));


### PR DESCRIPTION
## Summary

The guidelines are excellent — but without enforcement, the LLM can and will ignore them. This PR adds lightweight Claude Code hooks that make each principle **observable** in real time.

### What's added

| Hook | Event | Principle enforced | Behavior |
|:-----|:------|:-------------------|:---------|
| `think-before-coding.mjs` | PreToolUse | **#2 Simplicity First** | Warns when writing 200+ lines in a single tool call |
| `surgical-changes.mjs` | PostToolUse | **#3 Surgical Changes** | Warns on suppression markers (`eslint-disable`, `@ts-ignore`, `# nosec`), whitespace-only diffs, and comment removal |
| `goal-driven-stop.mjs` | Stop | **#4 Goal-Driven Execution** | Surfaces a verification checklist before task close |

### Design philosophy

- **Advisory, not blocking** — all hooks exit 0 with warnings on stderr. They nudge the agent without preventing it from working. This matches the README's note: *"These guidelines bias toward caution over speed. For trivial tasks, use judgment."*
- **Zero dependencies** — Node.js builtins only. No `npm install` needed.
- **Fail-open** — malformed stdin, missing fields, or any error → silent exit 0. The hooks never deadlock the agent.

### Files

```
hooks/
  hooks.json                  # Claude Code hook configuration
  think-before-coding.mjs     # PreToolUse — complexity warning
  surgical-changes.mjs        # PostToolUse — diff analysis
  goal-driven-stop.mjs        # Stop — verification checklist
CLAUDE.md                     # Added "Enforcement Hooks" section
```

### How it works

When a user installs this plugin, Claude Code discovers `hooks/hooks.json` automatically. On every Write/Edit call, the PreToolUse hook checks content size. After the write, PostToolUse scans for non-surgical patterns. On task close, the Stop hook reminds the agent to verify its work.

The agent sees the warnings in its context and can self-correct — exactly how Karpathy's principles are designed to work, but now with a feedback loop instead of relying on the LLM's memory of CLAUDE.md.

### Background

Built with patterns from [claude-crap](https://github.com/ahernandez-developer/claude-crap), a deterministic QA plugin that uses the same hook architecture for CRAP index, TDR, and SARIF-based quality gates. The approach is proven across 339 tests and polyglot monorepo support.