### PR TITLE
Add npx skills installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,13 +123,25 @@ echo "" >> CLAUDE.md
 curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
 ```
 
-**Option C: npx (global installation)**
+**Option C: skills CLI (global or npx)**
+
+Prerequisite: install Node.js so `npm`/`npx` are available.
+
+Use `npx` if you don't want to install the CLI globally:
 
 ```bash
 npx skills add https://github.com/forrestchang/andrej-karpathy-skills --skill karpathy-guidelines
 ```
 
-This command downloads the guidelines and installs them as a skill, making them available globally in Claude Code.
+Or install the CLI globally first:
+
+```bash
+npm install -g skills
+skills add https://github.com/forrestchang/andrej-karpathy-skills --skill karpathy-guidelines
+```
+
+The `npx` form downloads and runs the CLI on demand, while the global install gives you a persistent `skills` command. Both install the guidelines as a skill so they are available across your Claude Code projects.
+
 
 ## Key Insight
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ echo "" >> CLAUDE.md
 curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
 ```
 
+**Option C: npx (global installation)**
+
+```bash
+npx skills add https://github.com/forrestchang/andrej-karpathy-skills --skill karpathy-guidelines
+```
+
+This command downloads the guidelines and installs them as a skill, making them available globally in Claude Code.
+
 ## Key Insight
 
 From Andrej:


### PR DESCRIPTION
## Description

Added Option C in the README installation section using npx command to globally install the karpathy-guidelines skill.