### PR TITLE
add the examples to skill so its loaded by claude code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,4 +62,8 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 
 ---
 
+For concrete before/after code examples of each principle, see the Examples section in the skill file.
+
+---
+
 **These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/skills/karpathy-guidelines/SKILL.md
+++ b/skills/karpathy-guidelines/SKILL.md
@@ -65,3 +65,77 @@ For multi-step tasks, state a brief plan:
 ```
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+## Examples
+
+### 1. Think Before Coding
+
+**User:** "Add a feature to export user data"
+
+❌ Silently assumes format, fields, scope, writes full implementation  
+✅ Lists assumptions, asks: export all users? which format? which fields? what volume?
+
+**User:** "Make the search faster"
+
+❌ Adds caching + async + connection pooling without asking  
+✅ Presents 3 interpretations (response time / throughput / perceived speed) with effort estimates, asks which matters
+
+---
+
+### 2. Simplicity First
+
+**User:** "Add a function to calculate discount"
+
+❌ Abstract base class + strategy pattern + dataclass config + calculator class (~60 lines)  
+✅ `def calculate_discount(amount, percent): return amount * (percent / 100)` (2 lines)
+
+**User:** "Save user preferences to database"
+
+❌ PreferenceManager with cache, validator, merge flag, notify flag, 60+ lines  
+✅ `db.execute("UPDATE users SET preferences = ? WHERE id = ?", (json.dumps(preferences), user_id))`
+
+---
+
+### 3. Surgical Changes
+
+**User:** "Fix the bug where empty emails crash the validator"
+
+❌ Also improves email regex, adds username length/alphanumeric checks, changes comments  
+✅ Only patches the `if not user_data.get('email')` line to handle empty strings
+
+**User:** "Add logging to the upload function"
+
+❌ Adds type hints, docstring, changes quote style, reformats whitespace, rewrites boolean logic  
+✅ Adds `logger.info/error/exception` calls only, matches existing single-quote style
+
+---
+
+### 4. Goal-Driven Execution
+
+**User:** "Fix the authentication system"
+
+❌ "I'll review, identify issues, make improvements, test" — no verifiable criteria  
+✅ Defines: write test for specific bug → verify it fails → fix → verify it passes → run full suite
+
+**User:** "Add rate limiting to the API"
+
+❌ Full Redis + multi-strategy + config system in one 300-line commit, no steps  
+✅ 4 incremental steps each with explicit verify criteria, independently deployable
+
+**User:** "The sorting breaks with duplicate scores"
+
+❌ Immediately changes sort logic without reproducing the bug  
+✅ Writes failing test first → confirms it reproduces → fixes → confirms test passes
+
+---
+
+## Anti-Patterns Summary
+
+| Principle | Anti-Pattern | Fix |
+|-----------|-------------|-----|
+| Think Before Coding | Silently picks interpretation | State assumptions, ask first |
+| Simplicity First | Strategy pattern for one discount | One function until complexity is needed |
+| Surgical Changes | Reformats while fixing bug | Only change lines tied to the request |
+| Goal-Driven | "Review and improve" | "Test reproduces bug → fix → passes" |


### PR DESCRIPTION
"Hey, nice examples! Just curious — EXAMPLES.md isn't referenced in plugin.json, SKILL.md, or the CLAUDE.md, so it won't be loaded by Claude Code automatically. Was this intentional, or should it be integrated into the skill/plugin somehow (e.g. appended to SKILL.md or mentioned in the README as an optional install)?"


this was a comment about how the examples file is not loaded to claude code and the simplest fix for that is just to append it at the bottom and then and reference it in claude.md
even tho it's not the full examples file, its fine for that