### PR TITLE
feature: Add OpenCode plugin support

### DIFF
--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -6,15 +6,13 @@
 
 ## Installation
 
-Add karpathy-guidelines to the `plugin` array in your `opencode.json` (global or project-level):
+Just run the following command in your terminal:
 
-```json
-{
-  "plugin": ["karpathy-guidelines@git+https://github.com/forrestchang/andrej-karpathy-skills.git"]
-}
+```bash
+ npm install karpathy-guidelines@git+https://github.com/forrestchang/andrej-karpathy-skills.git --prefix ~/.config/opencode
 ```
 
-Restart OpenCode. That's it — the plugin auto-installs and registers the skill.
+NOT NEED to estart OpenCode. That's it — the plugin auto-installs and registers the skill.
 
 Verify by asking: "use skill tool to list skills"
 
@@ -45,15 +43,15 @@ This plugin:
 
 ## Updating
 
-Karpathy Guidelines updates automatically when you restart OpenCode (if using Git URL).
+Updating
 
-To pin a specific version:
+To update to the latest version, simply re-run the installation command:
 
-```json
-{
-  "plugin": ["karpathy-guidelines@git+https://github.com/forrestchang/andrej-karpathy-skills.git#v1.0.0"]
-}
+```bash
+npm install karpathy-guidelines@git+https://github.com/forrestchang/andrej-karpathy-skills.git --prefix ~/.config/opencode
 ```
+
+The plugin will be updated to the latest commit. No need to modify opencode.json or restart OpenCode.
 
 ## Tool Mapping
 

--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -1,0 +1,71 @@
+# Installing Karpathy Guidelines for OpenCode
+
+## Prerequisites
+
+- [OpenCode.ai](https://opencode.ai) installed
+
+## Installation
+
+Add karpathy-guidelines to the `plugin` array in your `opencode.json` (global or project-level):
+
+```json
+{
+  "plugin": ["karpathy-guidelines@git+https://github.com/forrestchang/andrej-karpathy-skills.git"]
+}
+```
+
+Restart OpenCode. That's it — the plugin auto-installs and registers the skill.
+
+Verify by asking: "use skill tool to list skills"
+
+## Usage
+
+Use OpenCode's native `skill` tool:
+
+```
+use skill tool to list skills
+use skill tool to load karpathy-guidelines
+```
+
+The guidelines will also be automatically injected into every session via bootstrap.
+
+## What It Does
+
+This plugin:
+
+1. **Registers the skill** - Makes `karpathy-guidelines` available via the skill tool
+2. **Injects bootstrap** - Adds behavioral guidelines to every session automatically
+
+## The Four Principles
+
+- **Think Before Coding** - Don't assume, surface tradeoffs, ask when unclear
+- **Simplicity First** - Minimum code that solves the problem, nothing speculative
+- **Surgical Changes** - Touch only what you must, clean up only your own mess
+- **Goal-Driven Execution** - Define success criteria, loop until verified
+
+## Updating
+
+Karpathy Guidelines updates automatically when you restart OpenCode (if using Git URL).
+
+To pin a specific version:
+
+```json
+{
+  "plugin": ["karpathy-guidelines@git+https://github.com/forrestchang/andrej-karpathy-skills.git#v1.0.0"]
+}
+```
+
+## Tool Mapping
+
+When skills reference Claude Code tools:
+
+- `TodoWrite` → `todowrite`
+- `Task` with subagents → `@mention` syntax
+- `Skill` tool → OpenCode's native `skill` tool
+- File operations → your native tools
+
+## Getting Help
+
+- Report issues: <https://github.com/forrestchang/andrej-karpathy-skills/issues>
+- Original project: <https://github.com/forrestchang/andrej-karpathy-skills>
+

--- a/.opencode/plugins/karpathy-guidelines.js
+++ b/.opencode/plugins/karpathy-guidelines.js
@@ -1,0 +1,85 @@
+/**
+ * Karpathy Guidelines plugin for OpenCode.ai
+ *
+ * Injects behavioral guidelines to reduce common LLM coding mistakes,
+ * derived from Andrej Karpathy's observations on LLM coding pitfalls.
+ */
+
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const extractAndStripFrontmatter = (content) => {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) return { frontmatter: {}, content };
+
+  const frontmatterStr = match[1];
+  const body = match[2];
+  const frontmatter = {};
+
+  for (const line of frontmatterStr.split('\n')) {
+    const colonIdx = line.indexOf(':');
+    if (colonIdx > 0) {
+      const key = line.slice(0, colonIdx).trim();
+      const value = line.slice(colonIdx + 1).trim().replace(/^["']|["']$/g, '');
+      frontmatter[key] = value;
+    }
+  }
+
+  return { frontmatter, content: body };
+};
+
+export const KarpathyGuidelinesPlugin = async ({ client, directory }) => {
+  const homeDir = os.homedir();
+  const karpathySkillsDir = path.resolve(__dirname, '../../skills');
+
+  const getBootstrapContent = () => {
+    const skillPath = path.join(karpathySkillsDir, 'karpathy-guidelines', 'SKILL.md');
+    if (!fs.existsSync(skillPath)) return null;
+
+    const fullContent = fs.readFileSync(skillPath, 'utf8');
+    const { content } = extractAndStripFrontmatter(fullContent);
+
+    const toolMapping = `**Tool Mapping for OpenCode:**
+When skills reference Claude Code tools, substitute OpenCode equivalents:
+- \`TodoWrite\` → \`todowrite\`
+- \`Task\` with subagents → Use OpenCode's subagent system (@mention)
+- \`Skill\` tool → OpenCode's native \`skill\` tool
+- \`Read\`, \`Write\`, \`Edit\`, \`Bash\` → Your native tools
+
+Use OpenCode's native \`skill\` tool to list and load skills.`;
+
+    return `<IMPORTANT_GUIDELINES>
+You have karpathy-guidelines loaded.
+
+**These behavioral guidelines are ALREADY ACTIVE - follow them in your work.**
+
+${content}
+
+${toolMapping}
+</IMPORTANT_GUIDELINES>`;
+  };
+
+  return {
+    config: async (config) => {
+      config.skills = config.skills || {};
+      config.skills.paths = config.skills.paths || [];
+      if (!config.skills.paths.includes(karpathySkillsDir)) {
+        config.skills.paths.push(karpathySkillsDir);
+      }
+    },
+
+    'experimental.chat.messages.transform': async (_input, output) => {
+      const bootstrap = getBootstrapContent();
+      if (!bootstrap || !output.messages.length) return;
+      const firstUser = output.messages.find(m => m.info.role === 'user');
+      if (!firstUser || !firstUser.parts.length) return;
+      if (firstUser.parts.some(p => p.type === 'text' && p.text.includes('IMPORTANT_GUIDELINES'))) return;
+      const ref = firstUser.parts[0];
+      firstUser.parts.unshift({ ...ref, type: 'text', text: bootstrap });
+    }
+  };
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "andrej-karpathy-skills",
+  "version": "0.1.0",
+  "type": "module",
+  "main": ".opencode/plugins/karpathy-guidelines.js"
+}


### PR DESCRIPTION
## Summary

Add OpenCode plugin support for `karpathy-guidelines` skill.

This PR adds OpenCode format support to enable the karpathy-guidelines skill to work with OpenCode. The plugin:
- Registers the skill path so OpenCode can discover it
- Injects behavioral guidelines into every session via bootstrap

## Changes

- `.opencode/INSTALL.md` - Installation instructions for OpenCode users
- `.opencode/plugins/karpathy-guidelines.js` - Plugin implementation
- `package.json` -npm install need

## Installation for test now

Just run the following command in your terminal:

```bash
 npm install karpathy-guidelines@git+https://github.com/Kiruno-lz/andrej-karpathy-skills.git --prefix ~/.config/opencode
```

NOT NEED to estart OpenCode. That's it — the plugin auto-installs and registers the skill.

Verify by asking: "use skill tool to list skills"