### PR TITLE
docs: add Vietnamese translations for documentation

### DIFF
--- a/CLAUDE.vi.md
+++ b/CLAUDE.vi.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+Các nguyên tắc hành vi giúp giảm những lỗi phổ biến khi LLM viết code. Có thể ghép với hướng dẫn riêng của project khi cần.
+
+**Đánh đổi:** Các nguyên tắc này ưu tiên sự cẩn trọng hơn tốc độ. Với tác vụ đơn giản, hãy dùng phán đoán của bạn.
+
+## 1. Suy Nghĩ Trước Khi Code
+
+**Đừng giả định. Đừng che giấu sự mơ hồ. Hãy nêu rõ các đánh đổi.**
+
+Trước khi triển khai:
+- Nêu rõ các giả định của bạn. Nếu chưa chắc, hãy hỏi.
+- Nếu có nhiều cách hiểu, hãy trình bày chúng, đừng tự chọn trong im lặng.
+- Nếu có cách đơn giản hơn, hãy nói ra. Phản biện khi cần.
+- Nếu có điều gì chưa rõ, hãy dừng lại. Chỉ ra điều gì đang gây bối rối. Hỏi.
+
+## 2. Ưu Tiên Sự Đơn Giản
+
+**Chỉ viết lượng code tối thiểu để giải quyết vấn đề. Không thêm phần suy đoán trước.**
+
+- Không thêm tính năng ngoài yêu cầu.
+- Không tạo abstraction cho phần code chỉ dùng một lần.
+- Không thêm "tính linh hoạt" hay "khả năng cấu hình" nếu không được yêu cầu.
+- Không viết xử lý lỗi cho các tình huống không thể xảy ra.
+- Nếu bạn viết 200 dòng trong khi 50 dòng là đủ, hãy viết lại.
+
+Hãy tự hỏi: "Một senior engineer có thấy đoạn này quá phức tạp không?" Nếu có, hãy đơn giản hóa.
+
+## 3. Chỉnh Sửa Có Chủ Đích
+
+**Chỉ chạm vào những gì bắt buộc. Chỉ dọn thứ do chính bạn tạo ra.**
+
+Khi sửa code sẵn có:
+- Đừng "cải thiện" code, comment, hay format ở khu vực lân cận.
+- Đừng refactor thứ không bị hỏng.
+- Hãy khớp với style hiện có, kể cả khi bạn thích cách khác.
+- Nếu thấy dead code không liên quan, hãy nhắc tới nó, đừng tự xóa.
+
+Khi thay đổi của bạn tạo ra phần thừa:
+- Xóa import/variable/function trở nên không dùng nữa do CHÍNH thay đổi của bạn gây ra.
+- Đừng xóa dead code có sẵn từ trước nếu không được yêu cầu.
+
+Phép thử: Mỗi dòng thay đổi đều phải truy được trực tiếp về yêu cầu của người dùng.
+
+## 4. Thực Thi Theo Mục Tiêu
+
+**Xác định tiêu chí thành công. Lặp lại cho tới khi kiểm chứng được.**
+
+Biến các tác vụ thành mục tiêu có thể xác minh:
+- "Thêm validation" → "Viết test cho input không hợp lệ, rồi làm cho test pass"
+- "Sửa bug" → "Viết test tái hiện bug, rồi làm cho test pass"
+- "Refactor X" → "Đảm bảo test pass trước và sau khi refactor"
+
+Với các tác vụ nhiều bước, hãy nêu một kế hoạch ngắn:
+```
+1. [Bước] → verify: [kiểm tra]
+2. [Bước] → verify: [kiểm tra]
+3. [Bước] → verify: [kiểm tra]
+```
+
+Tiêu chí thành công mạnh giúp bạn tự lặp và tự kiểm chứng. Tiêu chí yếu ("làm cho nó chạy được") sẽ dẫn đến phải hỏi đi hỏi lại.
+
+---
+
+**Những nguyên tắc này đang phát huy tác dụng nếu:** diff có ít thay đổi thừa hơn, ít phải viết lại do quá phức tạp hơn, và câu hỏi làm rõ xuất hiện trước khi triển khai thay vì sau khi mắc lỗi.

--- a/EXAMPLES.vi.md
+++ b/EXAMPLES.vi.md
@@ -16,7 +16,7 @@ Các ví dụ code thực tế minh họa bốn nguyên tắc. Mỗi ví dụ ch
 def export_users(format='json'):
     """Xuất tất cả người dùng ra file."""
     users = User.query.all()
-    
+
     if format == 'json':
         with open('users.json', 'w') as f:
             json.dump([u.to_dict() for u in users], f)
@@ -25,7 +25,7 @@ def export_users(format='json'):
             writer = csv.DictWriter(f, fieldnames=['id', 'email', 'name'])
             writer.writeheader()
             writer.writerows([u.to_dict() for u in users])
-    
+
     return f"Exported {len(users)} users"
 ```
 
@@ -116,14 +116,14 @@ class DiscountStrategy(ABC):
 class PercentageDiscount(DiscountStrategy):
     def __init__(self, percentage: float):
         self.percentage = percentage
-    
+
     def calculate(self, amount: float) -> float:
         return amount * (self.percentage / 100)
 
 class FixedDiscount(DiscountStrategy):
     def __init__(self, fixed_amount: float):
         self.fixed_amount = fixed_amount
-    
+
     def calculate(self, amount: float) -> float:
         return min(self.fixed_amount, amount)
 
@@ -136,7 +136,7 @@ class DiscountConfig:
 class DiscountCalculator:
     def __init__(self, config: DiscountConfig):
         self.config = config
-    
+
     def apply_discount(self, amount: float) -> float:
         if amount < self.config.min_purchase:
             return 0
@@ -171,37 +171,37 @@ class PreferenceManager:
         self.db = db
         self.cache = cache or InMemoryCache()
         self.validator = validator or DefaultValidator()
-    
-    def save(self, user_id: int, prefs: dict, 
-             merge: bool = True, 
+
+    def save(self, user_id: int, prefs: dict,
+             merge: bool = True,
              validate: bool = True,
              notify: bool = False) -> bool:
         """Lưu preferences với tùy chọn merge, validation, và notification."""
-        
+
         if validate:
             errors = self.validator.validate(prefs)
             if errors:
                 raise ValidationError(errors)
-        
+
         existing = self.get(user_id) if merge else {}
-        
+
         if merge:
             existing.update(prefs)
             prefs = existing
-        
+
         self.db.execute(
             "UPDATE users SET preferences = ? WHERE id = ?",
             (json.dumps(prefs), user_id)
         )
-        
+
         if self.cache:
             self.cache.set(f"prefs:{user_id}", prefs)
-        
+
         if notify:
             self.notify_preference_change(user_id, prefs)
-        
+
         return True
-    
+
     def notify_preference_change(self, user_id: int, prefs: dict):
         # Lại thêm 30 dòng nữa cho một tính năng không ai yêu cầu
         pass
@@ -236,16 +236,16 @@ def save_preferences(db, user_id: int, preferences: dict):
 -     if not user_data.get('email'):
 +     """Xác thực dữ liệu người dùng."""
 +     email = user_data.get('email', '').strip()
-+     
++
 +     # Xác thực email
 +     if not email:
           raise ValueError("Email required")
--     
+-
 -     # Basic email validation
 -     if '@' not in user_data['email']:
 +     if '@' not in email or '.' not in email.split('@')[1]:
           raise ValueError("Invalid email")
-      
+
 -     # Check username
 -     if not user_data.get('username'):
 +     # Xác thực username
@@ -256,7 +256,7 @@ def save_preferences(db, user_id: int, preferences: dict):
 +         raise ValueError("Username too short")
 +     if not username.isalnum():
 +         raise ValueError("Username must be alphanumeric")
-      
+
       return True
 ```
 
@@ -275,16 +275,16 @@ def save_preferences(db, user_id: int, preferences: dict):
 +     email = user_data.get('email', '')
 +     if not email or not email.strip():
           raise ValueError("Email required")
-      
+
       # Basic email validation
 -     if '@' not in user_data['email']:
 +     if '@' not in email:
           raise ValueError("Invalid email")
-      
+
       # Check username
       if not user_data.get('username'):
           raise ValueError("Username required")
-      
+
       return True
 ```
 
@@ -301,13 +301,13 @@ def save_preferences(db, user_id: int, preferences: dict):
 + def upload_file(file_path: str, destination: str) -> bool:
 +     """Upload file lên đích với logging."""
 +     logger.info(f"Uploading {file_path} to {destination}")
-+     
++
       try:
 -         with open(file_path, 'rb') as f:
 -             data = f.read()
--         
+-
 -         response = requests.post(destination, files={'file': data})
--         
+-
 -         if response.status_code == 200:
 -             return True
 -         else:
@@ -316,12 +316,12 @@ def save_preferences(db, user_id: int, preferences: dict):
 +             data = f.read()
 +         response = requests.post(destination, files={"file": data})
 +         success = response.status_code == 200
-+         
++
 +         if success:
 +             logger.info(f"Upload successful: {file_path}")
 +         else:
 +             logger.error(f"Upload failed: {file_path}, status={response.status_code}")
-+         
++
 +         return success
       except Exception as e:
 -         print(f"Error: {e}")
@@ -340,17 +340,17 @@ def save_preferences(db, user_id: int, preferences: dict):
 
 ```diff
 + import logging
-+ 
++
 + logger = logging.getLogger(__name__)
-+ 
++
   def upload_file(file_path, destination):
 +     logger.info(f'Starting upload: {file_path}')
       try:
           with open(file_path, 'rb') as f:
               data = f.read()
-          
+
           response = requests.post(destination, files={'file': data})
-          
+
           if response.status_code == 200:
 +             logger.info(f'Upload successful: {file_path}')
               return True
@@ -474,9 +474,9 @@ def test_sort_with_duplicate_scores():
         {'name': 'Bob', 'score': 100},
         {'name': 'Charlie', 'score': 90},
     ]
-    
+
     result = sort_scores(scores)
-    
+
     # Bug ở đây: thứ tự trở nên không xác định khi có phần tử trùng điểm
     # Chạy test này nhiều lần, kết quả phải nhất quán
     assert result[0]['score'] == 100

--- a/EXAMPLES.vi.md
+++ b/EXAMPLES.vi.md
@@ -1,0 +1,522 @@
+# Ví Dụ
+
+Các ví dụ code thực tế minh họa bốn nguyên tắc. Mỗi ví dụ cho thấy LLM thường làm sai ở đâu và nên sửa như thế nào.
+
+---
+
+## 1. Suy Nghĩ Trước Khi Code
+
+### Ví Dụ 1: Giả Định Ẩn
+
+**Yêu cầu của người dùng:** "Thêm tính năng export dữ liệu người dùng"
+
+**❌ Điều LLM Thường Làm (Giả định sai)**
+
+```python
+def export_users(format='json'):
+    """Xuất tất cả người dùng ra file."""
+    users = User.query.all()
+    
+    if format == 'json':
+        with open('users.json', 'w') as f:
+            json.dump([u.to_dict() for u in users], f)
+    elif format == 'csv':
+        with open('users.csv', 'w') as f:
+            writer = csv.DictWriter(f, fieldnames=['id', 'email', 'name'])
+            writer.writeheader()
+            writer.writerows([u.to_dict() for u in users])
+    
+    return f"Exported {len(users)} users"
+```
+
+**Vấn đề:**
+- Tự cho rằng phải export TOÀN BỘ người dùng (còn pagination? quyền riêng tư?)
+- Tự quyết định vị trí file mà không hỏi
+- Tự quyết định các field cần có
+- Tự suy ra fieldnames cho CSV mà không kiểm tra cấu trúc dữ liệu thật
+
+**✅ Điều Nên Xảy Ra (Làm rõ giả định)**
+
+```
+Trước khi triển khai, tôi cần làm rõ:
+
+1. **Phạm vi**: Export toàn bộ người dùng hay chỉ một tập đã lọc? (liên quan đến quyền riêng tư)
+2. **Định dạng**: Bạn nói "export" là muốn:
+   - Tải file trên trình duyệt?
+   - Chạy background job rồi gửi email?
+   - API endpoint trả dữ liệu?
+3. **Field**: Cần những field nào của người dùng? (một số có thể nhạy cảm)
+4. **Khối lượng**: Thông thường có bao nhiêu người dùng? (ảnh hưởng tới cách triển khai)
+
+Cách đơn giản nhất: thêm một API endpoint trả JSON có phân trang.
+Nếu export ra file thì tôi cần thêm thông tin.
+
+Bạn muốn hướng nào?
+```
+
+### Ví Dụ 2: Nhiều Cách Diễn Giải
+
+**Yêu cầu của người dùng:** "Làm cho phần search nhanh hơn"
+
+**❌ Điều LLM Thường Làm (Tự chọn trong im lặng)**
+
+```python
+# Thêm cache, database index, và xử lý async
+# mà không hỏi "nhanh hơn" ở đây nghĩa là gì
+@lru_cache(maxsize=1000)
+async def search(query: str) -> List[Result]:
+    # ... 200 dòng code tối ưu hóa
+```
+
+**✅ Điều Nên Xảy Ra**
+
+```
+"Làm cho phần search nhanh hơn" có thể có nghĩa là:
+
+1. **Thời gian phản hồi nhanh hơn** (< 100ms thay vì 500ms)
+   - Thêm database index
+   - Cache các truy vấn phổ biến
+   - Ước lượng công: 2 giờ
+
+2. **Xử lý được nhiều truy vấn đồng thời hơn** (throughput)
+   - Thêm async/await
+   - Connection pooling
+   - Ước lượng công: 4 giờ
+
+3. **Cảm giác nhanh hơn với người dùng** (UX)
+   - Hiển thị một phần kết quả ngay lập tức
+   - Progressive loading
+   - Ước lượng công: 3 giờ
+
+Hiện tại search mất khoảng ~500ms với truy vấn thông thường.
+Khía cạnh nào quan trọng nhất với use case của bạn?
+```
+
+---
+
+## 2. Ưu Tiên Sự Đơn Giản
+
+### Ví Dụ 1: Abstraction Quá Mức
+
+**Yêu cầu của người dùng:** "Thêm hàm tính discount"
+
+**❌ Điều LLM Thường Làm (Overengineered)**
+
+```python
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Protocol, Union
+from dataclasses import dataclass
+
+class DiscountStrategy(ABC):
+    @abstractmethod
+    def calculate(self, amount: float) -> float:
+        pass
+
+class PercentageDiscount(DiscountStrategy):
+    def __init__(self, percentage: float):
+        self.percentage = percentage
+    
+    def calculate(self, amount: float) -> float:
+        return amount * (self.percentage / 100)
+
+class FixedDiscount(DiscountStrategy):
+    def __init__(self, fixed_amount: float):
+        self.fixed_amount = fixed_amount
+    
+    def calculate(self, amount: float) -> float:
+        return min(self.fixed_amount, amount)
+
+@dataclass
+class DiscountConfig:
+    strategy: DiscountStrategy
+    min_purchase: float = 0.0
+    max_discount: float = float('inf')
+
+class DiscountCalculator:
+    def __init__(self, config: DiscountConfig):
+        self.config = config
+    
+    def apply_discount(self, amount: float) -> float:
+        if amount < self.config.min_purchase:
+            return 0
+        discount = self.config.strategy.calculate(amount)
+        return min(discount, self.config.max_discount)
+
+# Chỉ một phép tính đơn giản mà phải setup hơn 30 dòng
+```
+
+**✅ Điều Nên Xảy Ra (Đơn giản)**
+
+```python
+def calculate_discount(amount: float, percent: float) -> float:
+    """Tính số tiền được giảm. percent nên nằm trong khoảng 0-100."""
+    return amount * (percent / 100)
+
+# Cách dùng
+discount = calculate_discount(100.0, 10.0)  # giảm 10 đô
+```
+
+**Khi nào nên thêm độ phức tạp:** Chỉ khi bạn thực sự cần nhiều loại discount khác nhau. Nếu yêu cầu đó đến sau, lúc ấy hãy refactor.
+
+### Ví Dụ 2: Tính Năng Suy Đoán Trước
+
+**Yêu cầu của người dùng:** "Lưu user preferences vào database"
+
+**❌ Điều LLM Thường Làm (Tính năng không cần thiết)**
+
+```python
+class PreferenceManager:
+    def __init__(self, db, cache=None, validator=None):
+        self.db = db
+        self.cache = cache or InMemoryCache()
+        self.validator = validator or DefaultValidator()
+    
+    def save(self, user_id: int, prefs: dict, 
+             merge: bool = True, 
+             validate: bool = True,
+             notify: bool = False) -> bool:
+        """Lưu preferences với tùy chọn merge, validation, và notification."""
+        
+        if validate:
+            errors = self.validator.validate(prefs)
+            if errors:
+                raise ValidationError(errors)
+        
+        existing = self.get(user_id) if merge else {}
+        
+        if merge:
+            existing.update(prefs)
+            prefs = existing
+        
+        self.db.execute(
+            "UPDATE users SET preferences = ? WHERE id = ?",
+            (json.dumps(prefs), user_id)
+        )
+        
+        if self.cache:
+            self.cache.set(f"prefs:{user_id}", prefs)
+        
+        if notify:
+            self.notify_preference_change(user_id, prefs)
+        
+        return True
+    
+    def notify_preference_change(self, user_id: int, prefs: dict):
+        # Lại thêm 30 dòng nữa cho một tính năng không ai yêu cầu
+        pass
+```
+
+**✅ Điều Nên Xảy Ra (Chỉ làm đúng yêu cầu)**
+
+```python
+def save_preferences(db, user_id: int, preferences: dict):
+    """Lưu user preferences vào database."""
+    db.execute(
+        "UPDATE users SET preferences = ? WHERE id = ?",
+        (json.dumps(preferences), user_id)
+    )
+```
+
+**Chỉ thêm sau nếu cần:** Cache (khi hiệu năng trở nên quan trọng), validation (khi xuất hiện dữ liệu xấu), merge (khi yêu cầu thực sự xuất hiện).
+
+---
+
+## 3. Chỉnh Sửa Có Chủ Đích
+
+### Ví Dụ 1: Refactor Tiện Tay
+
+**Yêu cầu của người dùng:** "Sửa bug validator bị crash khi email rỗng"
+
+**❌ Điều LLM Thường Làm (Làm quá nhiều)**
+
+```diff
+  def validate_user(user_data):
+-     # Check email format
+-     if not user_data.get('email'):
++     """Xác thực dữ liệu người dùng."""
++     email = user_data.get('email', '').strip()
++     
++     # Xác thực email
++     if not email:
+          raise ValueError("Email required")
+-     
+-     # Basic email validation
+-     if '@' not in user_data['email']:
++     if '@' not in email or '.' not in email.split('@')[1]:
+          raise ValueError("Invalid email")
+      
+-     # Check username
+-     if not user_data.get('username'):
++     # Xác thực username
++     username = user_data.get('username', '').strip()
++     if not username:
+          raise ValueError("Username required")
++     if len(username) < 3:
++         raise ValueError("Username too short")
++     if not username.isalnum():
++         raise ValueError("Username must be alphanumeric")
+      
+      return True
+```
+
+**Vấn đề:**
+- "Cải thiện" phần validation email vượt quá bug cần sửa
+- Thêm validation cho username mà không ai yêu cầu
+- Đổi comment
+- Thêm docstring
+
+**✅ Điều Nên Xảy Ra (Chỉnh sửa gọn)**
+
+```diff
+  def validate_user(user_data):
+      # Check email format
+-     if not user_data.get('email'):
++     email = user_data.get('email', '')
++     if not email or not email.strip():
+          raise ValueError("Email required")
+      
+      # Basic email validation
+-     if '@' not in user_data['email']:
++     if '@' not in email:
+          raise ValueError("Invalid email")
+      
+      # Check username
+      if not user_data.get('username'):
+          raise ValueError("Username required")
+      
+      return True
+```
+
+**Chỉ thay đổi:** Những dòng trực tiếp sửa lỗi xử lý email rỗng.
+
+### Ví Dụ 2: Trôi Style
+
+**Yêu cầu của người dùng:** "Thêm logging vào hàm upload"
+
+**❌ Điều LLM Thường Làm (Reformat toàn bộ)**
+
+```diff
+- def upload_file(file_path, destination):
++ def upload_file(file_path: str, destination: str) -> bool:
++     """Upload file lên đích với logging."""
++     logger.info(f"Uploading {file_path} to {destination}")
++     
+      try:
+-         with open(file_path, 'rb') as f:
+-             data = f.read()
+-         
+-         response = requests.post(destination, files={'file': data})
+-         
+-         if response.status_code == 200:
+-             return True
+-         else:
+-             return False
++         with open(file_path, "rb") as f:
++             data = f.read()
++         response = requests.post(destination, files={"file": data})
++         success = response.status_code == 200
++         
++         if success:
++             logger.info(f"Upload successful: {file_path}")
++         else:
++             logger.error(f"Upload failed: {file_path}, status={response.status_code}")
++         
++         return success
+      except Exception as e:
+-         print(f"Error: {e}")
++         logger.exception(f"Upload error for {file_path}: {e}")
+          return False
+```
+
+**Vấn đề:**
+- Đổi style quote (`''` thành `""`)
+- Thêm type hint mà không ai yêu cầu
+- Thêm docstring
+- Đổi whitespace
+- Đổi luôn logic trả về boolean
+
+**✅ Điều Nên Xảy Ra (Khớp style hiện có)**
+
+```diff
++ import logging
++ 
++ logger = logging.getLogger(__name__)
++ 
+  def upload_file(file_path, destination):
++     logger.info(f'Starting upload: {file_path}')
+      try:
+          with open(file_path, 'rb') as f:
+              data = f.read()
+          
+          response = requests.post(destination, files={'file': data})
+          
+          if response.status_code == 200:
++             logger.info(f'Upload successful: {file_path}')
+              return True
+          else:
++             logger.error(f'Upload failed: {file_path}, status={response.status_code}')
+              return False
+      except Exception as e:
+-         print(f"Error: {e}")
++         logger.exception(f'Upload error: {file_path}')
+          return False
+```
+
+**Đã khớp:** Single quotes, không có type hint, giữ nguyên pattern boolean hiện có, và style spacing cũ.
+
+---
+
+## 4. Thực Thi Theo Mục Tiêu
+
+### Ví Dụ 1: Mơ Hồ vs. Có Thể Kiểm Chứng
+
+**Yêu cầu của người dùng:** "Sửa hệ thống authentication"
+
+**❌ Điều LLM Thường Làm (Cách tiếp cận mơ hồ)**
+
+```
+Tôi sẽ sửa hệ thống authentication bằng cách:
+1. Review code
+2. Xác định vấn đề
+3. Thực hiện cải thiện
+4. Test lại thay đổi
+
+[Tiếp tục sửa code mà không có tiêu chí thành công rõ ràng]
+```
+
+**✅ Điều Nên Xảy Ra (Mục tiêu có thể kiểm chứng)**
+
+```
+Để "sửa authentication", tôi cần xác định tiêu chí thành công.
+Cụ thể chúng ta đang giải quyết vấn đề nào?
+
+Nếu vấn đề là "người dùng vẫn còn đăng nhập sau khi đổi mật khẩu":
+
+Kế hoạch:
+1. Viết test: Đổi mật khẩu → xác minh session cũ bị vô hiệu hóa
+   Verify: Test fail (tái hiện được bug)
+
+2. Triển khai: Vô hiệu hóa session khi đổi mật khẩu
+   Verify: Test pass
+
+3. Kiểm tra edge case: Nhiều session đang hoạt động, thay đổi đồng thời
+   Verify: Các test bổ sung pass
+
+4. Xác minh không có regression: Các test auth hiện có vẫn pass
+   Verify: Toàn bộ test suite xanh
+
+Mức test coverage hiện tại cho auth: [hiển thị coverage]
+Bạn đang gặp vấn đề auth cụ thể nào?
+```
+
+### Ví Dụ 2: Nhiều Bước Có Xác Minh
+
+**Yêu cầu của người dùng:** "Thêm rate limiting cho API"
+
+**❌ Điều LLM Thường Làm (Làm tất cả cùng lúc)**
+
+```python
+# Triển khai trọn bộ rate limiting với Redis, nhiều chiến lược,
+# hệ thống cấu hình và monitoring trong một commit 300 dòng
+# Không có các bước xác minh rõ ràng
+```
+
+**✅ Điều Nên Xảy Ra (Từng bước, có xác minh)**
+
+```
+Kế hoạch cho rate limiting:
+
+1. Thêm rate limiting cơ bản trong memory (một endpoint)
+   Verify:
+   - Test: 100 request → 10 request đầu thành công, phần còn lại nhận 429
+   - Thủ công: curl endpoint 11 lần, thấy lỗi rate limit
+
+2. Tách thành middleware (áp dụng cho mọi endpoint)
+   Verify:
+   - Test: Rate limit áp dụng cho /users và /posts
+   - Các test endpoint hiện có vẫn pass
+
+3. Thêm Redis backend (cho multi-server)
+   Verify:
+   - Test: Rate limit vẫn giữ sau khi app restart
+   - Test: Hai instance app dùng chung bộ đếm rate limit
+
+4. Thêm cấu hình (mỗi endpoint có mức riêng)
+   Verify:
+   - Test: /search cho phép 10/phút, /users cho phép 100/phút
+   - File cấu hình được parse đúng
+
+Mỗi bước đều có thể xác minh và deploy độc lập.
+Bắt đầu từ bước 1 chứ?
+```
+
+### Ví Dụ 3: Xác Minh Theo Kiểu Test-First
+
+**Yêu cầu của người dùng:** "Phần sorting bị lỗi khi có duplicate scores"
+
+**❌ Điều LLM Thường Làm (Sửa mà không tái hiện)**
+
+```python
+# Đổi logic sort ngay lập tức mà chưa xác nhận bug
+def sort_scores(scores):
+    return sorted(scores, key=lambda x: (-x['score'], x['name']))
+```
+
+**✅ Điều Nên Xảy Ra (Tái hiện trước)**
+
+```python
+# 1. Trước tiên, viết test để tái hiện vấn đề
+def test_sort_with_duplicate_scores():
+    """Test sorting khi nhiều item có cùng score."""
+    scores = [
+        {'name': 'Alice', 'score': 100},
+        {'name': 'Bob', 'score': 100},
+        {'name': 'Charlie', 'score': 90},
+    ]
+    
+    result = sort_scores(scores)
+    
+    # Bug ở đây: thứ tự trở nên không xác định khi có phần tử trùng điểm
+    # Chạy test này nhiều lần, kết quả phải nhất quán
+    assert result[0]['score'] == 100
+    assert result[1]['score'] == 100
+    assert result[2]['score'] == 90
+
+# Verify: Chạy test 10 lần → fail vì thứ tự không nhất quán
+
+# 2. Bây giờ mới sửa bằng stable sort
+def sort_scores(scores):
+    """Sắp xếp score giảm dần, nếu hòa thì theo tên tăng dần."""
+    return sorted(scores, key=lambda x: (-x['score'], x['name']))
+
+# Verify: Test pass ổn định
+```
+
+---
+
+## Tóm Tắt Các Phản Mẫu
+
+| Nguyên tắc | Phản mẫu | Cách sửa |
+|-----------|----------|----------|
+| Suy Nghĩ Trước Khi Code | Âm thầm giả định định dạng file, field, phạm vi | Liệt kê giả định rõ ràng, yêu cầu làm rõ |
+| Ưu Tiên Sự Đơn Giản | Dùng strategy pattern cho một phép tính discount duy nhất | Một hàm là đủ cho tới khi thực sự cần thêm độ phức tạp |
+| Chỉnh Sửa Có Chủ Đích | Đổi quote, thêm type hint trong lúc sửa bug | Chỉ sửa những dòng trực tiếp xử lý vấn đề được báo |
+| Thực Thi Theo Mục Tiêu | "Tôi sẽ review và cải thiện code" | "Viết test cho bug X → làm cho test pass → xác minh không regression" |
+
+## Ý Chính
+
+Các ví dụ "quá phức tạp" không hẳn là sai rõ ràng, chúng vẫn bám theo design pattern và best practice. Vấn đề nằm ở **thời điểm**: chúng thêm độ phức tạp trước khi thực sự cần, dẫn đến:
+
+- Code khó hiểu hơn
+- Sinh ra nhiều bug hơn
+- Tốn nhiều thời gian triển khai hơn
+- Khó test hơn
+
+Các phiên bản "đơn giản" thì:
+- Dễ hiểu hơn
+- Triển khai nhanh hơn
+- Dễ test hơn
+- Có thể refactor sau khi độ phức tạp thực sự xuất hiện
+
+**Code tốt là code giải quyết vấn đề của hôm nay một cách đơn giản, không phải giải quyết sớm vấn đề của ngày mai.**

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A single `CLAUDE.md` file to improve Claude Code behavior, derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.
 
-English | [简体中文](./README.zh.md)
+English | [简体中文](./README.zh.md) | [Tiếng Việt](./README.vi.md)
 
 ## The Problems
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -1,0 +1,171 @@
+# Hướng Dẫn Claude Code Theo Cảm Hứng Từ Karpathy
+
+> Hãy xem dự án mới của tôi [Multica](https://github.com/multica-ai/multica) — một nền tảng mã nguồn mở để chạy và quản lý coding agent với các skill có thể tái sử dụng.
+>
+> Theo dõi tôi trên X: [https://x.com/jiayuan_jy](https://x.com/jiayuan_jy)
+
+Một file `CLAUDE.md` duy nhất để cải thiện cách Claude Code làm việc, được đúc kết từ [những quan sát của Andrej Karpathy](https://x.com/karpathy/status/2015883857489522876) về các lỗi thường gặp khi LLM viết code.
+
+[English](./README.md) | [简体中文](./README.zh.md) | Tiếng Việt
+
+## Vấn Đề
+
+Từ bài đăng của Andrej:
+
+> "Các mô hình tự đưa ra giả định sai thay bạn rồi cứ thế làm tiếp mà không kiểm tra. Chúng không quản lý sự bối rối của mình, không hỏi để làm rõ, không chỉ ra chỗ mâu thuẫn, không trình bày các đánh đổi, và không phản biện khi đáng lẽ phải phản biện."
+
+> "Chúng rất thích làm code và API trở nên quá phức tạp, phình to các tầng abstraction, không dọn dead code... triển khai một cấu trúc cồng kềnh hơn 1000 dòng trong khi 100 dòng là đủ."
+
+> "Đôi khi chúng vẫn sửa hoặc xóa comment và code mà chúng chưa hiểu đủ, như một tác dụng phụ, dù phần đó không liên quan trực tiếp đến nhiệm vụ."
+
+## Giải Pháp
+
+Bốn nguyên tắc trong một file, trực tiếp xử lý các vấn đề này:
+
+| Nguyên tắc | Xử lý |
+|-----------|-------|
+| **Suy Nghĩ Trước Khi Code** | Giả định sai, mơ hồ bị che giấu, thiếu đánh đổi |
+| **Ưu Tiên Sự Đơn Giản** | Quá phức tạp, abstraction cồng kềnh |
+| **Chỉnh Sửa Có Chủ Đích** | Sửa lan sang phần không liên quan, đụng vào phần không nên đụng |
+| **Thực Thi Theo Mục Tiêu** | Tận dụng test-first và tiêu chí thành công có thể kiểm chứng |
+
+## Chi Tiết Bốn Nguyên Tắc
+
+### 1. Suy Nghĩ Trước Khi Code
+
+**Đừng giả định. Đừng che giấu sự mơ hồ. Hãy nêu rõ các đánh đổi.**
+
+LLM thường âm thầm chọn một cách hiểu rồi cứ thế triển khai. Nguyên tắc này buộc quá trình suy luận phải rõ ràng:
+
+- **Nêu rõ giả định** — Nếu chưa chắc, hãy hỏi thay vì đoán
+- **Trình bày nhiều cách hiểu** — Khi có mơ hồ, đừng tự chọn trong im lặng
+- **Phản biện khi cần** — Nếu có cách đơn giản hơn, hãy nói ra
+- **Dừng lại khi chưa rõ** — Chỉ ra điều gì đang mơ hồ và yêu cầu làm rõ
+
+### 2. Ưu Tiên Sự Đơn Giản
+
+**Chỉ viết lượng code tối thiểu để giải quyết vấn đề. Không thêm phần suy đoán trước.**
+
+Để chống lại xu hướng overengineering:
+
+- Không thêm tính năng ngoài yêu cầu
+- Không tạo abstraction cho phần code chỉ dùng một lần
+- Không thêm "tính linh hoạt" hay "khả năng cấu hình" nếu không được yêu cầu
+- Không viết xử lý lỗi cho các tình huống không thể xảy ra
+- Nếu 200 dòng có thể viết còn 50 dòng, hãy viết lại
+
+**Phép thử:** Một senior engineer có thấy đoạn này đang bị làm quá không? Nếu có, hãy đơn giản hóa.
+
+### 3. Chỉnh Sửa Có Chủ Đích
+
+**Chỉ chạm vào những gì bắt buộc. Chỉ dọn thứ do chính bạn tạo ra.**
+
+Khi sửa code sẵn có:
+
+- Đừng "cải thiện" code, comment, hay format ở khu vực lân cận
+- Đừng refactor thứ không bị hỏng
+- Hãy khớp với style hiện có, kể cả khi bạn thích cách khác
+- Nếu thấy dead code không liên quan, hãy nhắc tới nó, đừng tự xóa
+
+Khi thay đổi của bạn tạo ra phần thừa:
+
+- Xóa import/variable/function trở nên không dùng nữa do CHÍNH thay đổi của bạn gây ra
+- Đừng xóa dead code có sẵn từ trước nếu không được yêu cầu
+
+**Phép thử:** Mỗi dòng thay đổi đều phải truy được trực tiếp về yêu cầu của người dùng.
+
+### 4. Thực Thi Theo Mục Tiêu
+
+**Xác định tiêu chí thành công. Lặp lại cho tới khi kiểm chứng được.**
+
+Biến các yêu cầu mệnh lệnh thành mục tiêu có thể xác minh:
+
+| Thay vì... | Hãy biến thành... |
+|------------|-------------------|
+| "Thêm validation" | "Viết test cho input không hợp lệ, rồi làm cho test pass" |
+| "Sửa bug" | "Viết test tái hiện bug, rồi làm cho test pass" |
+| "Refactor X" | "Đảm bảo test pass trước và sau khi refactor" |
+
+Với các tác vụ nhiều bước, hãy nêu một kế hoạch ngắn:
+
+```
+1. [Bước] → verify: [kiểm tra]
+2. [Bước] → verify: [kiểm tra]
+3. [Bước] → verify: [kiểm tra]
+```
+
+Tiêu chí thành công mạnh giúp LLM tự lặp và tự kiểm chứng. Tiêu chí yếu ("làm cho nó chạy được") sẽ dẫn đến phải hỏi đi hỏi lại.
+
+## Cài Đặt
+
+**Tùy chọn A: Plugin Claude Code (khuyến nghị)**
+
+Từ bên trong Claude Code, trước tiên hãy thêm marketplace:
+```
+/plugin marketplace add forrestchang/andrej-karpathy-skills
+```
+
+Sau đó cài plugin:
+```
+/plugin install andrej-karpathy-skills@karpathy-skills
+```
+
+Việc này cài bộ nguyên tắc dưới dạng plugin Claude Code, giúp skill khả dụng trên mọi project của bạn.
+
+**Tùy chọn B: CLAUDE.md (theo từng project)**
+
+Project mới:
+```bash
+curl -o CLAUDE.md https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md
+```
+
+Project đã có sẵn (append):
+```bash
+echo "" >> CLAUDE.md
+curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
+```
+
+## Dùng Với Cursor
+
+Repo này đã có sẵn Cursor project rule ([`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc)), nên cùng bộ nguyên tắc đó sẽ được áp dụng khi bạn mở project bằng Cursor. Xem **[CURSOR.md](CURSOR.md)** để biết cách thiết lập, dùng rule này cho project khác, và mối quan hệ của nó với Claude Code.
+
+## Ý Chính
+
+Từ Andrej:
+
+> "LLM đặc biệt giỏi lặp cho đến khi đạt mục tiêu cụ thể... Đừng nói nó phải làm gì, hãy đưa ra tiêu chí thành công rồi quan sát nó tự hoàn thành."
+
+Nguyên tắc "Thực Thi Theo Mục Tiêu" đúc kết ý này: biến yêu cầu mệnh lệnh thành mục tiêu mang tính khai báo, có vòng lặp xác minh.
+
+## Dấu Hiệu Cho Thấy Nó Hoạt Động
+
+Những nguyên tắc này đang phát huy tác dụng nếu bạn thấy:
+
+- **Ít thay đổi thừa hơn trong diff** — Chỉ có các thay đổi thực sự được yêu cầu
+- **Ít phải viết lại do quá phức tạp** — Code ngay từ đầu đã gọn
+- **Câu hỏi làm rõ xuất hiện trước khi triển khai** — Không phải sau khi đã làm sai
+- **PR sạch và gọn** — Không có refactor tiện tay hay "cải thiện" lan man
+
+## Tùy Biến
+
+Các nguyên tắc này được thiết kế để ghép với hướng dẫn riêng của từng project. Hãy thêm chúng vào `CLAUDE.md` hiện có của bạn hoặc tạo file mới.
+
+Với rule riêng theo project, bạn có thể thêm các phần như:
+
+```markdown
+## Hướng Dẫn Riêng Của Project
+
+- Dùng TypeScript strict mode
+- Mọi API endpoint phải có test
+- Tuân theo pattern xử lý lỗi hiện có trong `src/utils/errors.ts`
+```
+
+## Ghi Chú Về Đánh Đổi
+
+Các nguyên tắc này ưu tiên **sự cẩn trọng hơn tốc độ**. Với các tác vụ rất nhỏ (sửa typo đơn giản, one-liner quá rõ ràng), hãy dùng phán đoán của bạn, không phải thay đổi nào cũng cần đủ toàn bộ quy trình.
+
+Mục tiêu là giảm các sai sót tốn kém trong công việc không tầm thường, chứ không phải làm chậm các tác vụ đơn giản.
+
+## Giấy Phép
+
+MIT

--- a/README.zh.md
+++ b/README.zh.md
@@ -6,7 +6,7 @@
 
 一个单一的 `CLAUDE.md` 文件，用于改善 Claude Code 的行为，源自 [Andrej Karpathy 的观察](https://x.com/karpathy/status/2015883857489522876) 关于 LLM 编码陷阱的总结。
 
-[English](./README.md) | 简体中文
+[English](./README.md) | 简体中文 | [Tiếng Việt](./README.vi.md)
 
 ## 问题所在
 

--- a/skills/karpathy-guidelines/SKILL.vi.md
+++ b/skills/karpathy-guidelines/SKILL.vi.md
@@ -1,0 +1,67 @@
+---
+name: karpathy-guidelines
+description: Các nguyên tắc hành vi giúp giảm những lỗi phổ biến khi LLM viết code. Dùng khi viết, review, hoặc refactor code để tránh overcomplication, chỉnh sửa có chủ đích, nêu rõ giả định, và xác định tiêu chí thành công có thể kiểm chứng.
+license: MIT
+---
+
+# Karpathy Guidelines
+
+Các nguyên tắc hành vi giúp giảm những lỗi phổ biến khi LLM viết code, được đúc kết từ [những quan sát của Andrej Karpathy](https://x.com/karpathy/status/2015883857489522876) về các lỗi thường gặp khi LLM lập trình.
+
+**Đánh đổi:** Các nguyên tắc này ưu tiên sự cẩn trọng hơn tốc độ. Với tác vụ đơn giản, hãy dùng phán đoán của bạn.
+
+## 1. Suy Nghĩ Trước Khi Code
+
+**Đừng giả định. Đừng che giấu sự mơ hồ. Hãy nêu rõ các đánh đổi.**
+
+Trước khi triển khai:
+- Nêu rõ các giả định của bạn. Nếu chưa chắc, hãy hỏi.
+- Nếu có nhiều cách hiểu, hãy trình bày chúng, đừng tự chọn trong im lặng.
+- Nếu có cách đơn giản hơn, hãy nói ra. Phản biện khi cần.
+- Nếu có điều gì chưa rõ, hãy dừng lại. Chỉ ra điều gì đang gây bối rối. Hỏi.
+
+## 2. Ưu Tiên Sự Đơn Giản
+
+**Chỉ viết lượng code tối thiểu để giải quyết vấn đề. Không thêm phần suy đoán trước.**
+
+- Không thêm tính năng ngoài yêu cầu.
+- Không tạo abstraction cho phần code chỉ dùng một lần.
+- Không thêm "tính linh hoạt" hay "khả năng cấu hình" nếu không được yêu cầu.
+- Không viết xử lý lỗi cho các tình huống không thể xảy ra.
+- Nếu bạn viết 200 dòng trong khi 50 dòng là đủ, hãy viết lại.
+
+Hãy tự hỏi: "Một senior engineer có thấy đoạn này quá phức tạp không?" Nếu có, hãy đơn giản hóa.
+
+## 3. Chỉnh Sửa Có Chủ Đích
+
+**Chỉ chạm vào những gì bắt buộc. Chỉ dọn thứ do chính bạn tạo ra.**
+
+Khi sửa code sẵn có:
+- Đừng "cải thiện" code, comment, hay format ở khu vực lân cận.
+- Đừng refactor thứ không bị hỏng.
+- Hãy khớp với style hiện có, kể cả khi bạn thích cách khác.
+- Nếu thấy dead code không liên quan, hãy nhắc tới nó, đừng tự xóa.
+
+Khi thay đổi của bạn tạo ra phần thừa:
+- Xóa import/variable/function trở nên không dùng nữa do CHÍNH thay đổi của bạn gây ra.
+- Đừng xóa dead code có sẵn từ trước nếu không được yêu cầu.
+
+Phép thử: Mỗi dòng thay đổi đều phải truy được trực tiếp về yêu cầu của người dùng.
+
+## 4. Thực Thi Theo Mục Tiêu
+
+**Xác định tiêu chí thành công. Lặp lại cho tới khi kiểm chứng được.**
+
+Biến các tác vụ thành mục tiêu có thể xác minh:
+- "Thêm validation" → "Viết test cho input không hợp lệ, rồi làm cho test pass"
+- "Sửa bug" → "Viết test tái hiện bug, rồi làm cho test pass"
+- "Refactor X" → "Đảm bảo test pass trước và sau khi refactor"
+
+Với các tác vụ nhiều bước, hãy nêu một kế hoạch ngắn:
+```
+1. [Bước] → verify: [kiểm tra]
+2. [Bước] → verify: [kiểm tra]
+3. [Bước] → verify: [kiểm tra]
+```
+
+Tiêu chí thành công mạnh giúp bạn tự lặp và tự kiểm chứng. Tiêu chí yếu ("làm cho nó chạy được") sẽ dẫn đến phải hỏi đi hỏi lại.


### PR DESCRIPTION
## Summary

- add `README.vi.md`, `CLAUDE.vi.md`, `EXAMPLES.vi.md`, and `skills/karpathy-guidelines/SKILL.vi.md`
- add Vietnamese language links to `README.md` and `README.zh.md`
- keep the scope documentation-only and aligned with the repository's existing translation pattern

## Why

There is already English and Simplified Chinese coverage, plus open translation work in other languages. Vietnamese is not covered yet, so this adds a clean localization path without changing the core guidance.

## Test plan

- [x] Verify markdown files are well-formed with `git diff --check`
- [x] Verify language switcher links point to the new Vietnamese README
- [x] Confirm no code or plugin logic changed
