### PR TITLE
Add Codex skill metadata and docs

### DIFF
--- a/CURSOR.md
+++ b/CURSOR.md
@@ -18,11 +18,16 @@ This project includes a **Cursor project rule** so the Karpathy-inspired behavio
 
 If you want the same content as a reusable skill under `~/.cursor/skills`, use [`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md). You can copy or symlink it into your personal skills directory; use whatever layout you use for other skills.
 
-## Claude Code vs Cursor
+## Use the same skill with Codex
+
+This repo also includes Codex metadata in [`skills/karpathy-guidelines/agents/openai.yaml`](skills/karpathy-guidelines/agents/openai.yaml). Copy or symlink the whole [`skills/karpathy-guidelines`](skills/karpathy-guidelines) folder into `~/.codex/skills/karpathy-guidelines`, then restart Codex. The skill can then be invoked as `$karpathy-guidelines`.
+
+## Claude Code vs Cursor vs Codex
 
 - **Claude Code:** Install via the plugin marketplace and [`README.md`](README.md) instructions; the plugin exposes the skill from this repo. Per-project use can also rely on `CLAUDE.md`.
 - **Cursor:** Use the committed `.cursor/rules/` file as described above. Cursor does not read `.claude-plugin/` or `CLAUDE.md` by default.
+- **Codex:** Install the bundled skill into `~/.codex/skills`. Codex reads `agents/openai.yaml` for UI metadata and can invoke the skill explicitly as `$karpathy-guidelines` or implicitly when relevant.
 
 ## For contributors
 
-When you change the four principles, keep **[`CLAUDE.md`](CLAUDE.md)** and **[`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc)** in sync. If the published skill/plugin text should match, update **[`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md)** as well.
+When you change the four principles, keep **[`CLAUDE.md`](CLAUDE.md)** and **[`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc)** in sync. If the published skill/plugin text should match, update **[`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md)** as well, and keep **[`skills/karpathy-guidelines/agents/openai.yaml`](skills/karpathy-guidelines/agents/openai.yaml)** aligned for Codex.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Karpathy-Inspired Claude Code Guidelines
+# Karpathy-Inspired Coding Agent Guidelines
 
 > Check out my new project [Multica](https://github.com/multica-ai/multica) — an open-source platform for running and managing coding agents with reusable skills.
 >
 > Follow me on X: [https://x.com/jiayuan_jy](https://x.com/jiayuan_jy)
 
-A single `CLAUDE.md` file to improve Claude Code behavior, derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.
+A small set of `CLAUDE.md`, Cursor rules, and reusable skills to improve Claude Code, Cursor, and Codex behavior, derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.
 
 English | [简体中文](./README.zh.md)
 
@@ -125,9 +125,26 @@ echo "" >> CLAUDE.md
 curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
 ```
 
+**Option C: Codex skill**
+
+From the repository root, copy or symlink the bundled skill into `~/.codex/skills`:
+
+```bash
+mkdir -p ~/.codex/skills
+cp -R skills/karpathy-guidelines ~/.codex/skills/
+```
+
+Then restart Codex to pick up the new skill. After that, you can invoke it explicitly with `$karpathy-guidelines`, or let Codex load it implicitly when the task fits.
+
 ## Using with Cursor
 
 This repository includes a committed Cursor project rule ([`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc)) so the same guidelines apply when you open the project in Cursor. See **[CURSOR.md](CURSOR.md)** for setup, using the rule in other projects, and how this relates to Claude Code.
+
+## Using with Codex
+
+This repository includes a Codex-compatible skill definition in [`skills/karpathy-guidelines`](skills/karpathy-guidelines), including [`agents/openai.yaml`](skills/karpathy-guidelines/agents/openai.yaml) for Codex UI metadata and invocation behavior.
+
+Install that folder into `~/.codex/skills` to make the guidelines available across projects. If you make changes to the shared skill text, keep the Codex metadata aligned as well.
 
 ## Key Insight
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,10 +1,10 @@
-# 受 Karpathy 启发的 Claude Code 指南
+# 受 Karpathy 启发的编码智能体指南
 
 > 查看我的新项目 [Multica](https://github.com/multica-ai/multica) —— 一个用于运行和管理编码智能体的开源平台，支持可复用的技能。
 >
 > 在 X 上关注我：[https://x.com/jiayuan_jy](https://x.com/jiayuan_jy)
 
-一个单一的 `CLAUDE.md` 文件，用于改善 Claude Code 的行为，源自 [Andrej Karpathy 的观察](https://x.com/karpathy/status/2015883857489522876) 关于 LLM 编码陷阱的总结。
+一组 `CLAUDE.md`、Cursor 规则和可复用技能，用于改善 Claude Code、Cursor 和 Codex 的行为，源自 [Andrej Karpathy 的观察](https://x.com/karpathy/status/2015883857489522876) 关于 LLM 编码陷阱的总结。
 
 [English](./README.md) | 简体中文
 
@@ -125,9 +125,26 @@ echo "" >> CLAUDE.md
 curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
 ```
 
+**选项 C：Codex 技能**
+
+在仓库根目录执行，将内置技能复制或软链接到 `~/.codex/skills`：
+
+```bash
+mkdir -p ~/.codex/skills
+cp -R skills/karpathy-guidelines ~/.codex/skills/
+```
+
+然后重启 Codex，让它重新加载新技能。之后你可以显式使用 `$karpathy-guidelines` 调用它，也可以让 Codex 在匹配任务时隐式加载。
+
 ## 在 Cursor 中使用
 
 本仓库包含一个已提交的 Cursor 项目规则 ([`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc))，因此在 Cursor 中打开项目时同样适用这些指南。详情请参见 **[CURSOR.md](CURSOR.md)**，包括如何在其他项目中使用该规则，以及它与 Claude Code 的关系。
+
+## 在 Codex 中使用
+
+本仓库还提供了兼容 Codex 的技能定义，位于 [`skills/karpathy-guidelines`](skills/karpathy-guidelines)，并包含用于 Codex UI 元数据和调用行为的 [`agents/openai.yaml`](skills/karpathy-guidelines/agents/openai.yaml)。
+
+将该目录安装到 `~/.codex/skills` 后，这套指南就可以在不同项目中复用。如果你修改了共享技能文本，也请同步更新 Codex 元数据。
 
 ## 核心洞察
 

--- a/skills/karpathy-guidelines/SKILL.md
+++ b/skills/karpathy-guidelines/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: karpathy-guidelines
-description: Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, surface assumptions, and define verifiable success criteria.
+description: "Apply Karpathy-style coding guardrails that reduce common LLM engineering mistakes. Use when writing, reviewing, debugging, or refactoring code: surface assumptions before acting, prefer the simplest viable change, keep edits surgical, and define verifiable success criteria before implementation."
 license: MIT
 ---
 

--- a/skills/karpathy-guidelines/agents/openai.yaml
+++ b/skills/karpathy-guidelines/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Karpathy Guidelines"
+  short_description: "Apply careful coding guardrails"
+  default_prompt: "Use $karpathy-guidelines for this coding task so you surface assumptions, keep changes minimal, and verify the result."
+policy:
+  allow_implicit_invocation: true


### PR DESCRIPTION
## Summary

Add first-class Codex support to this repo while keeping the existing Claude Code and Cursor flows unchanged.

## Changes

- add Codex skill metadata in `skills/karpathy-guidelines/agents/openai.yaml`
- update `skills/karpathy-guidelines/SKILL.md` description to better match Codex skill triggering
- document Codex installation and usage in `README.md`
- add the same Codex documentation in `README.zh.md`
- update `CURSOR.md` contributor guidance to mention keeping Codex metadata in sync with the shared skill text

## Notes

- this does not change the existing Claude plugin or Cursor rule behavior
- the new `openai.yaml` is Codex-specific metadata that improves UI presentation and skill invocation behavior

## Validation

- validated `skills/karpathy-guidelines` with the Codex skill validator
- checked the diff for formatting and repo consistency