### PR TITLE
Add multilingual translations for code guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,177 @@ The goal is reducing costly mistakes on non-trivial work, not slowing down simpl
 ## License
 
 MIT
+
+
+translated new version also at the end zip file has such more translated languages which are Portuguese Galician Catalan Romanian Polish Czech Slovak Croatian Slovenian Swedish Icelandic Danish Norwegian Finnish Hungarian Estonian Turkish Azerbaijani Turkmen Indonesian Malay Vietnamese Filipino (Tagalog) Haitian Creole Welsh Basque Quechua Māori Sami Languages 
+
+while this text has german spanish french italian dutch.
+
+---
+
+**German (Deutsch)**
+
+# Karpathy-inspirierte Claude-Code-Richtlinien
+
+**Die vier Prinzipien:**
+
+1. **Denke vor dem Codieren**  
+   Mach keine stillschweigenden Annahmen. Verstecke keine Verwirrung. Zeige Trade-offs auf.  
+   - Formuliere Annahmen explizit  
+   - Stelle bei Mehrdeutigkeit mehrere Interpretationen dar  
+   - Dränge zurück, wenn ein einfacherer Ansatz möglich ist  
+   - Stoppe und frage nach Klärung, wenn etwas unklar ist
+
+2. **Einfachheit zuerst**  
+   Schreibe den minimalen Code, der das Problem löst. Nichts Spekulatives.  
+   - Keine Features, die nicht angefordert wurden  
+   - Keine Abstraktionen für Einmal-Code  
+   - Keine „Flexibilität“ oder Konfigurierbarkeit, die nicht verlangt wurde  
+   - Wenn 200 Zeilen auf 50 reduziert werden können, dann tue es
+
+3. **Chirurgische Änderungen**  
+   Berühre nur das, was du unbedingt musst. Räume nur dein eigenes Chaos auf.  
+   - Verbessere keinen benachbarten Code, Kommentare oder Formatierung  
+   - Refaktoriere nichts, was nicht kaputt ist  
+   - Passe dich dem bestehenden Stil an  
+   - Entferne nur Imports/Variablen/Funktionen, die durch *deine* Änderungen überflüssig geworden sind
+
+4. **Zielgetriebene Ausführung**  
+   Definiere klare Erfolgskriterien und arbeite in Schleifen, bis sie erfüllt sind.  
+   Verwandele Aufgaben in verifizierbare Ziele (z. B. „Schreibe Tests für ungültige Eingaben und mache sie grün“).
+
+---
+
+**Spanish (Español)**
+
+# Directrices de Código Claude inspiradas en Karpathy
+
+**Los cuatro principios:**
+
+1. **Piensa antes de codificar**  
+   No hagas suposiciones silenciosas. No ocultes confusión. Muestra trade-offs.  
+   - Declara las suposiciones explícitamente  
+   - Presenta múltiples interpretaciones cuando haya ambigüedad  
+   - Rechaza enfoques innecesarios si existe uno más simple  
+   - Detente y pide aclaración cuando estés confundido
+
+2. **Simplicidad primero**  
+   Código mínimo que resuelva el problema. Nada especulativo.  
+   - Sin funcionalidades que no se pidieron  
+   - Sin abstracciones para código de un solo uso  
+   - Sin “flexibilidad” o configurabilidad no solicitada  
+   - Si 200 líneas se pueden reducir a 50, hazlo
+
+3. **Cambios quirúrgicos**  
+   Toca solo lo que debes. Limpia solo tu propio desorden.  
+   - No “mejores” código, comentarios o formato adyacente  
+   - No refactorices lo que no está roto  
+   - Mantén el estilo existente  
+   - Elimina solo las importaciones/variables/funciones que *tus* cambios dejaron sin usar
+
+4. **Ejecución orientada a objetivos**  
+   Define criterios de éxito claros y trabaja en bucles hasta verificarlos.  
+   Convierte tareas imperativas en metas verificables (ej. “Escribe tests para entradas inválidas y haz que pasen”).
+
+---
+
+**French (Français)**
+
+# Directives de Code Claude inspirées de Karpathy
+
+**Les quatre principes :**
+
+1. **Réfléchis avant de coder**  
+   Ne fais pas d’hypothèses silencieuses. Ne cache pas ta confusion. Présente les compromis.  
+   - Énonce tes hypothèses explicitement  
+   - Présente plusieurs interprétations en cas d’ambiguïté  
+   - Pousse en arrière quand une approche plus simple existe  
+   - Arrête-toi et demande des clarifications quand tu es confus
+
+2. **Simplicité d’abord**  
+   Code minimal qui résout le problème. Rien de spéculatif.  
+   - Aucune fonctionnalité au-delà de ce qui a été demandé  
+   - Aucune abstraction pour du code à usage unique  
+   - Aucune « flexibilité » ou configurabilité non demandée  
+   - Si 200 lignes peuvent devenir 50, réécris
+
+3. **Changements chirurgicaux**  
+   Ne touche que ce que tu dois absolument. Nettoie seulement ton propre désordre.  
+   - N’améliore pas le code, les commentaires ou le formatage adjacent  
+   - Ne refactorise pas ce qui n’est pas cassé  
+   - Respecte le style existant  
+   - Supprime uniquement les imports/variables/fonctions rendus inutiles par *tes* modifications
+
+4. **Exécution orientée objectifs**  
+   Définit des critères de succès clairs et boucle jusqu’à vérification.  
+   Transforme les tâches en objectifs vérifiables (ex. « Écris des tests pour les entrées invalides et fais-les passer »).
+
+---
+
+**Italian (Italiano)**
+
+# Linee guida per il Codice Claude ispirate a Karpathy
+
+**I quattro principi:**
+
+1. **Pensa prima di codificare**  
+   Non fare supposizioni silenziose. Non nascondere confusione. Evidenzia i trade-off.  
+   - Dichiarare esplicitamente le assunzioni  
+   - Presentare più interpretazioni in caso di ambiguità  
+   - Opporsi quando esiste un approccio più semplice  
+   - Fermati e chiedi chiarimenti quando sei confuso
+
+2. **Semplicità prima di tutto**  
+   Codice minimo che risolve il problema. Niente di speculativo.  
+   - Nessuna funzionalità oltre a quanto richiesto  
+   - Nessuna astrazione per codice a uso singolo  
+   - Nessuna “flessibilità” o configurabilità non richiesta  
+   - Se 200 righe possono diventare 50, riscrivi
+
+3. **Modifiche chirurgiche**  
+   Toccare solo ciò che è strettamente necessario. Pulire solo il proprio disordine.  
+   - Non “migliorare” codice, commenti o formattazione adiacente  
+   - Non rifattorizzare ciò che non è rotto  
+   - Mantenere lo stile esistente  
+   - Rimuovere solo gli import/variabili/funzioni resi inutilizzati dalle *proprie* modifiche
+
+4. **Esecuzione orientata agli obiettivi**  
+   Definisci criteri di successo chiari e itera fino alla verifica.  
+   Trasforma i compiti in obiettivi verificabili (es. «Scrivi test per input non validi e falli passare»).
+
+---
+
+**Dutch (Nederlands)**
+
+# Karpathy-geïnspireerde Claude Code-richtlijnen
+
+**De vier principes:**
+
+1. **Denk voordat je codeert**  
+   Maak geen stille aannames. Verberg geen verwarring. Toon trade-offs.  
+   - Formuleer aannames expliciet  
+   - Presenteer meerdere interpretaties bij ambiguïteit  
+   - Duw terug als een eenvoudigere aanpak mogelijk is  
+   - Stop en vraag om verduidelijking als je in de war bent
+
+2. **Eenvoud eerst**  
+   Minimale code die het probleem oplost. Niets speculatiefs.  
+   - Geen functionaliteiten die niet gevraagd zijn  
+   - Geen abstracties voor eenmalige code  
+   - Geen “flexibiliteit” of configureerbaarheid die niet is gevraagd  
+   - Als 200 regels kunnen worden teruggebracht tot 50, herschrijf dan
+
+3. **Chirurgische wijzigingen**  
+   Raak alleen aan wat je echt moet. Ruim alleen je eigen rommel op.  
+   - Verbeter geen aangrenzende code, comments of opmaak  
+   - Refactor niets wat niet kapot is  
+   - Houd de bestaande stijl aan  
+   - Verwijder alleen imports/variabelen/functies die door *jouw* wijzigingen ongebruikt zijn geraakt
+
+4. **Doelgerichte uitvoering**  
+   Definieer duidelijke succescriteria en werk in lussen tot ze geverifieerd zijn.  
+   Zet taken om in verifieerbare doelen (bijv. “Schrijf tests voor ongeldige invoer en laat ze slagen”).
+
+
+[karpathy-guidelines-multilang.zip](https://github.com/user-attachments/files/27044490/karpathy-guidelines-multilang.zip)
+


### PR DESCRIPTION
Added translations of Claude Code Guidelines in multiple languages including German, Spanish, French, Italian, Dutch, and  Portuguese Galician Catalan Romanian Polish Czech Slovak Croatian Slovenian Swedish Icelandic Danish Norwegian Finnish Hungarian Estonian Turkish Azerbaijani Turkmen Indonesian Malay Vietnamese Filipino (Tagalog) Haitian Creole Welsh Basque Quechua Māori Sami Languages- also