### PR TITLE
add kiro support

### DIFF
--- a/.kiro/steering/karpathy-guardrails.md
+++ b/.kiro/steering/karpathy-guardrails.md
@@ -1,0 +1,36 @@
+﻿---
+inclusion: auto
+---
+
+# Karpathy Guardrails - Behavioral Constraints
+
+> Derived from Andrej Karpathy's observations on LLM coding pitfalls.
+> Apply to ALL code interactions: writing, editing, reviewing, refactoring.
+
+## 1. Think Before Coding
+- State assumptions explicitly before implementing. If uncertain, ask.
+- Multiple interpretations exist → present options, DON'T pick silently.
+- A simpler approach exists → say so, push back when warranted.
+- Something is unclear → stop, name the confusion, ask.
+
+## 2. Simplicity First
+- Minimum code that solves the problem. Nothing beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- 200 lines when 50 would do → rewrite.
+
+## 3. Surgical Changes
+- ONLY touch what's directly related to the request.
+- DON'T "improve" surrounding code, comments, or formatting.
+- DON'T refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- Spot dead code → mention it, DON'T delete it (unless you created it).
+- Every changed line must trace back to the user's request.
+
+## 4. Goal-Driven Execution
+- Transform tasks into verifiable goals before coding:
+  - "Add validation" → "Write tests for invalid inputs, then make them pass"
+  - "Fix the bug" → "Write a test that reproduces it, then make it pass"
+  - "Refactor X" → "Ensure tests pass before and after"
+- Multi-step tasks → state a brief plan with verification for each step.

--- a/.kiro/steering/karpathy-guardrails.md
+++ b/.kiro/steering/karpathy-guardrails.md
@@ -1,4 +1,4 @@
-﻿---
+---
 inclusion: auto
 ---
 

--- a/KIRO.md
+++ b/KIRO.md
@@ -1,0 +1,43 @@
+# Using this repo with Kiro
+
+This project includes a **Kiro steering file** so the Karpathy-inspired behavioral guidelines apply automatically when you work here.
+
+## In this repository
+
+1. Open the folder in Kiro.
+2. The steering file [`.kiro/steering/karpathy-guardrails.md`](.kiro/steering/karpathy-guardrails.md) is committed with `inclusion: auto`, so Kiro applies it to every interaction without extra setup.
+3. You can verify it under Kiro's steering panel, where `karpathy-guardrails` should appear as an active rule.
+
+## Use the same guidelines in another project
+
+**Kiro (recommended):** Copy `.kiro/steering/karpathy-guardrails.md` into that project's `.kiro/steering/` directory (create the folders if needed). The `inclusion: auto` front-matter ensures it is applied automatically. Adjust or merge with existing steering files as you like.
+
+**Other tools:** If a stack only supports a root instruction file, copy [`CLAUDE.md`](CLAUDE.md) into that project instead (or merge its contents into your existing instructions).
+
+## Steering file front-matter
+
+The file uses Kiro's standard steering front-matter:
+
+```markdown
+---
+inclusion: auto
+---
+```
+
+`inclusion: auto` means Kiro includes the file for every agent interaction in the workspace. Change it to `manual` if you want to invoke it on-demand instead.
+
+## Claude Code vs Cursor vs Kiro
+
+- **Claude Code:** Install via the plugin marketplace per [`README.md`](README.md); per-project use can also rely on `CLAUDE.md`.
+- **Cursor:** Use the committed [`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc) file as described in [`CURSOR.md`](CURSOR.md).
+- **Kiro:** Use the committed `.kiro/steering/karpathy-guardrails.md` file as described in this file. Kiro does not read `.claude-plugin/`, `CLAUDE.md`, or `.cursor/rules/` by default.
+
+## For contributors
+
+When you change the four principles, keep all three rule files in sync:
+
+- **[`CLAUDE.md`](CLAUDE.md)**
+- **[`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc)**
+- **[`.kiro/steering/karpathy-guardrails.md`](.kiro/steering/karpathy-guardrails.md)**
+
+If the published skill/plugin text should also match, update **[`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md)** as well.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/
 
 This repository includes a committed Cursor project rule ([`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc)) so the same guidelines apply when you open the project in Cursor. See **[CURSOR.md](CURSOR.md)** for setup, using the rule in other projects, and how this relates to Claude Code.
 
+## Using with Kiro
+
+This repository includes a committed Kiro steering file ([`.kiro/steering/karpathy-guardrails.md`](.kiro/steering/karpathy-guardrails.md)) with `inclusion: auto`, so the same guidelines apply automatically when you open the project in Kiro. See **[KIRO.md](KIRO.md)** for setup, using the steering file in other projects, and how this relates to Claude Code and Cursor.
+
 ## Key Insight
 
 From Andrej:


### PR DESCRIPTION
## Summary

Add support for **Kiro** as a third IDE target alongside Claude Code and Cursor.
The Karpathy behavioral guardrails are now distributed as a Kiro steering file
(`.kiro/steering/karpathy-guardrails.md`) with `inclusion: auto`, so they apply
automatically to every agent interaction in the workspace — no manual setup required.

## Changes

| File | Type | Description |
|------|------|-------------|
| `.kiro/steering/karpathy-guardrails.md` | Added | Kiro steering file containing the four Karpathy principles, with `inclusion: auto` front-matter |
| `KIRO.md` | Added | Setup guide for Kiro users — copying the rule to other projects |
| `README.md` | Modified | Added "Using with Kiro" section linking to `.kiro/steering/karpathy-guardrails.md` and `KIRO.md` |


## Note

- The steering file uses a concise bullet-point format optimised for Kiro's context window,
  while preserving all four principles.
- Contributors should keep `.kiro/steering/karpathy-guardrails.md`, `CLAUDE.md`, and
  `.cursor/rules/karpathy-guidelines.mdc` in sync when the principles change
  (documented in `KIRO.md` under "For contributors").
- `inclusion: auto` can be changed to `manual` by users who prefer on-demand invocation.
- No change to .claude-plugin/ or plugin install steps; Claude users are unaffected.