### PR TITLE
Add `OpenCode`  plugin packaging

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,34 @@
+name: Publish npm package
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Install package metadata dependencies
+        run: npm install --package-lock-only
+
+      - name: Pack dry run
+        run: npm pack --dry-run
+
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Strong success criteria let the LLM loop independently. Weak criteria ("make it 
 
 ## Install
 
+OpenCode-specific installation details live in [opencode/OPENCODE.md](./opencode/OPENCODE.md).
+
 **Option A: Claude Code Plugin (recommended)**
 
 From within Claude Code, first add the marketplace:

--- a/opencode/OPENCODE.md
+++ b/opencode/OPENCODE.md
@@ -1,0 +1,48 @@
+# OpenCode
+
+This repo includes an OpenCode plugin under [`opencode/`](./).
+
+## Install
+
+Once published to npm:
+
+```text
+oc-plugin-karpathy-guidelines@latest
+```
+
+Or in OpenCode config:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["oc-plugin-karpathy-guidelines@latest"]
+}
+```
+
+For local development without npm publication:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["/absolute/path/to/andrej-karpathy-skills/opencode/plugin/server.js"]
+}
+```
+
+## Verify
+
+```bash
+opencode debug config
+```
+
+You should see the plugin path or package in the resolved `plugin` list.
+
+## Uninstall
+
+Remove the plugin entry from the `plugin` array in your OpenCode config.
+
+## Publish
+
+```bash
+npm login
+npm publish
+```

--- a/opencode/plugin/index.js
+++ b/opencode/plugin/index.js
@@ -1,0 +1,1 @@
+export { default, KarpathyGuidelinesPlugin } from "./server.js";

--- a/opencode/plugin/server.js
+++ b/opencode/plugin/server.js
@@ -1,0 +1,83 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const extractAndStripFrontmatter = (content) => {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) return { frontmatter: {}, content };
+
+  const frontmatterStr = match[1];
+  const body = match[2];
+  const frontmatter = {};
+
+  for (const line of frontmatterStr.split("\n")) {
+    const colonIdx = line.indexOf(":");
+    if (colonIdx > 0) {
+      const key = line.slice(0, colonIdx).trim();
+      const value = line.slice(colonIdx + 1).trim().replace(/^["']|["']$/g, "");
+      frontmatter[key] = value;
+    }
+  }
+
+  return { frontmatter, content: body };
+};
+
+const getBootstrapContent = (skillsDir) => {
+  const skillPath = path.join(skillsDir, "karpathy-guidelines", "SKILL.md");
+  if (!fs.existsSync(skillPath)) return null;
+
+  const fullContent = fs.readFileSync(skillPath, "utf8");
+  const { content } = extractAndStripFrontmatter(fullContent);
+
+  const toolMapping = `**Tool Mapping for OpenCode:**
+When skills reference Claude Code tools, substitute OpenCode equivalents:
+- \`TodoWrite\` -> \`todowrite\`
+- \`Task\` with subagents -> Use OpenCode's subagent system (@mention)
+- \`Skill\` tool -> OpenCode's native \`skill\` tool
+- \`Read\`, \`Write\`, \`Edit\`, \`Bash\` -> Your native tools
+
+Use OpenCode's native \`skill\` tool to list and load skills.`;
+
+  return `<IMPORTANT_GUIDELINES>
+You have karpathy-guidelines loaded.
+
+**These behavioral guidelines are ALREADY ACTIVE - follow them in your work.**
+
+${content}
+
+${toolMapping}
+</IMPORTANT_GUIDELINES>`;
+};
+
+export const KarpathyGuidelinesPlugin = async () => {
+  const skillsDir = path.resolve(__dirname, "../skills");
+
+  return {
+    config: async (config) => {
+      config.skills = config.skills || {};
+      config.skills.paths = config.skills.paths || [];
+      if (!config.skills.paths.includes(skillsDir)) {
+        config.skills.paths.push(skillsDir);
+      }
+    },
+
+    "experimental.chat.messages.transform": async (_input, output) => {
+      const bootstrap = getBootstrapContent(skillsDir);
+      if (!bootstrap || !output.messages.length) return;
+      const firstUser = output.messages.find((m) => m.info.role === "user");
+      if (!firstUser || !firstUser.parts.length) return;
+      if (firstUser.parts.some((p) => p.type === "text" && p.text.includes("IMPORTANT_GUIDELINES"))) return;
+      const ref = firstUser.parts[0];
+      firstUser.parts.unshift({ ...ref, type: "text", text: bootstrap });
+    },
+  };
+};
+
+const pluginModule = {
+  id: "karpathy-guidelines",
+  server: KarpathyGuidelinesPlugin,
+};
+
+export default pluginModule;

--- a/opencode/skills/karpathy-guidelines/SKILL.md
+++ b/opencode/skills/karpathy-guidelines/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: karpathy-guidelines
+description: Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, surface assumptions, and define verifiable success criteria.
+license: MIT
+---
+
+# Karpathy Guidelines
+
+Behavioral guidelines to reduce common LLM coding mistakes, derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/opencode/skills/karpathy-guidelines/SKILL.md
+++ b/opencode/skills/karpathy-guidelines/SKILL.md
@@ -66,6 +66,28 @@ For multi-step tasks, state a brief plan:
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
+## 5. Ambiguity First, Fast Feedback
+
+**If the request is underspecified, clarify before coding and do not go silent.**
+
+For ambiguous implementation requests:
+- Do not start coding yet.
+- Ask one short clarifying question before using tools when multiple reasonable implementations exist.
+- If you need to inspect the workspace to frame the question, send a brief progress update first.
+- Produce a user-visible reply before any non-trivial exploration or implementation.
+- Default behavior:
+  1. State the ambiguity in one sentence.
+  2. Ask one concrete question.
+  3. Wait for the answer.
+
+Bad:
+- User: "I need a script to rename files"
+- Assistant: starts searching the repo and writing code
+
+Good:
+- User: "I need a script to rename files"
+- Assistant: "The rename rule is missing. Do you need text replacement, extension changes, prefix/suffix changes, or an explicit name mapping?"
+
 ---
 
 **These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json.schemastore.org/package.json",
+  "name": "oc-plugin-karpathy-guidelines",
+  "version": "0.2.0",
+  "description": "OpenCode plugin that registers the karpathy-guidelines skill and injects it into new sessions.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./opencode/plugin/index.js",
+  "exports": {
+    ".": "./opencode/plugin/index.js",
+    "./server": {
+      "import": "./opencode/plugin/server.js",
+      "config": {
+        "enabled": true
+      }
+    }
+  },
+  "engines": {
+    "opencode": ">=1.3.14"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/antonillos/andrej-karpathy-skills.git"
+  },
+  "bugs": {
+    "url": "https://github.com/antonillos/andrej-karpathy-skills/issues"
+  },
+  "homepage": "https://github.com/antonillos/andrej-karpathy-skills#readme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "opencode",
+    "README.md",
+    "README.zh.md"
+  ],
+  "keywords": [
+    "opencode",
+    "plugin",
+    "karpathy",
+    "guidelines",
+    "llm"
+  ],
+  "peerDependencies": {
+    "@opencode-ai/plugin": "*"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "oc-plugin-karpathy-guidelines",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "OpenCode plugin that registers the karpathy-guidelines skill and injects it into new sessions.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
This PR adds `OpenCode` support by packaging the **Karpathy guidelines** as an installable plugin and documenting how to use it in `OpenCode`.

It also adds a small guideline update for ambiguous requests, encouraging clarification before implementation when multiple reasonable interpretations exist.

I noticed there is already interest in `OpenCode` support in #96. This version aims for the same outcome, but with a more explicit plugin package, npm-oriented metadata, and a self-contained `OpenCode` layout.

## Changes
- add an `OpenCode plugin` entrypoint and server
- register and inject the **karpathy-guidelines** skill in new `OpenCode` sessions
- add `OpenCode` installation and local development docs
- add package metadata for `npm` publication
- update the README to link to the `OpenCode` docs
- add ambiguity-first guidance to the skill content

## Why
This makes the repository useful beyond Claude Code without changing the existing workflow. Users can keep the same Karpathy-inspired guidance and install it directly in `OpenCode` as a reusable plugin.