### PR TITLE
Add Codex support docs and metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md
+
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,49 @@
+# Using this repo with Codex
+
+This repository now supports Codex in three practical ways:
+
+- `AGENTS.md` gives Codex project-level instructions when you open this repo, or when you copy the file into another project root.
+- `skills/karpathy-guidelines/SKILL.md` is a reusable Codex skill.
+- `skills/karpathy-guidelines/agents/openai.yaml` gives Codex UI metadata for the skill.
+
+## In this repository
+
+Open the folder in Codex. Codex reads `AGENTS.md` automatically as project guidance, so the behavioral guidelines apply while editing this repo.
+
+## Install as a Codex skill
+
+If your Codex install includes the skill installer, install directly from GitHub:
+
+```bash
+python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
+  --repo forrestchang/andrej-karpathy-skills \
+  --path skills/karpathy-guidelines
+```
+
+Restart Codex after installing so the new skill is discovered.
+
+Manual install works too:
+
+```bash
+mkdir -p ~/.codex/skills
+cp -R skills/karpathy-guidelines ~/.codex/skills/karpathy-guidelines
+```
+
+## Use in another project
+
+For per-project behavior, copy `AGENTS.md` into that project's root or merge its contents into an existing `AGENTS.md`.
+
+For reusable behavior across projects, install the skill once under `~/.codex/skills/karpathy-guidelines`.
+
+## Skill metadata
+
+The skill UI metadata lives at `skills/karpathy-guidelines/agents/openai.yaml`. Keep it short and focused so Codex can show a useful display name, description, and starter prompt.
+
+## For contributors
+
+When you change the four principles, keep these files aligned:
+
+- `AGENTS.md` for Codex project instructions
+- `CLAUDE.md` for Claude Code project instructions
+- `.cursor/rules/karpathy-guidelines.mdc` for Cursor
+- `skills/karpathy-guidelines/SKILL.md` for reusable skill installs

--- a/CURSOR.md
+++ b/CURSOR.md
@@ -12,17 +12,20 @@ This project includes a **Cursor project rule** so the Karpathy-inspired behavio
 
 **Cursor (recommended):** Copy `.cursor/rules/karpathy-guidelines.mdc` into that project’s `.cursor/rules/` directory (create the folders if needed). Adjust or merge with existing rules as you like.
 
+**Codex:** Copy [`AGENTS.md`](AGENTS.md) into that project root, or install [`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md) as a reusable skill. See [`CODEX.md`](CODEX.md).
+
 **Other tools:** If a stack only supports a root instruction file, copy [`CLAUDE.md`](CLAUDE.md) into that project instead (or merge its contents into your existing instructions).
 
 ## Optional: personal Agent Skills
 
 If you want the same content as a reusable skill under `~/.cursor/skills`, use [`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md). You can copy or symlink it into your personal skills directory; use whatever layout you use for other skills.
 
-## Claude Code vs Cursor
+## Claude Code vs Codex vs Cursor
 
+- **Codex:** Use `AGENTS.md` for project guidance, or install the reusable skill from `skills/karpathy-guidelines`.
 - **Claude Code:** Install via the plugin marketplace and [`README.md`](README.md) instructions; the plugin exposes the skill from this repo. Per-project use can also rely on `CLAUDE.md`.
 - **Cursor:** Use the committed `.cursor/rules/` file as described above. Cursor does not read `.claude-plugin/` or `CLAUDE.md` by default.
 
 ## For contributors
 
-When you change the four principles, keep **[`CLAUDE.md`](CLAUDE.md)** and **[`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc)** in sync. If the published skill/plugin text should match, update **[`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md)** as well.
+When you change the four principles, keep **[`AGENTS.md`](AGENTS.md)**, **[`CLAUDE.md`](CLAUDE.md)**, and **[`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc)** in sync. If the published skill/plugin text should match, update **[`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md)** as well.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Karpathy-Inspired Claude Code Guidelines
+# Karpathy-Inspired Coding Agent Guidelines
 
 > Check out my new project [Multica](https://github.com/multica-ai/multica) — an open-source platform for running and managing coding agents with reusable skills.
 >
 > Follow me on X: [https://x.com/jiayuan_jy](https://x.com/jiayuan_jy)
 
-A single `CLAUDE.md` file to improve Claude Code behavior, derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.
+A small set of agent instructions and skills to improve coding-agent behavior, derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.
 
 English | [简体中文](./README.zh.md)
 
@@ -112,7 +112,27 @@ Then install the plugin:
 
 This installs the guidelines as a Claude Code plugin, making the skill available across all your projects.
 
-**Option B: CLAUDE.md (per-project)**
+**Option B: Codex**
+
+This repo includes Codex-native integration:
+
+- [`AGENTS.md`](AGENTS.md) for project-level Codex instructions
+- [`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md) as a reusable Codex skill
+- [`skills/karpathy-guidelines/agents/openai.yaml`](skills/karpathy-guidelines/agents/openai.yaml) for Codex skill UI metadata
+
+If your Codex install includes the skill installer, install the skill directly from GitHub:
+
+```bash
+python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
+  --repo forrestchang/andrej-karpathy-skills \
+  --path skills/karpathy-guidelines
+```
+
+Restart Codex after installing. For per-project behavior without a global skill, copy [`AGENTS.md`](AGENTS.md) into your project root or merge it with an existing `AGENTS.md`.
+
+See **[CODEX.md](CODEX.md)** for details.
+
+**Option C: CLAUDE.md (per-project)**
 
 New project:
 ```bash

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,10 +1,10 @@
-# 受 Karpathy 启发的 Claude Code 指南
+# 受 Karpathy 启发的编码智能体指南
 
 > 查看我的新项目 [Multica](https://github.com/multica-ai/multica) —— 一个用于运行和管理编码智能体的开源平台，支持可复用的技能。
 >
 > 在 X 上关注我：[https://x.com/jiayuan_jy](https://x.com/jiayuan_jy)
 
-一个单一的 `CLAUDE.md` 文件，用于改善 Claude Code 的行为，源自 [Andrej Karpathy 的观察](https://x.com/karpathy/status/2015883857489522876) 关于 LLM 编码陷阱的总结。
+一组用于改善编码智能体行为的指令和技能，源自 [Andrej Karpathy 的观察](https://x.com/karpathy/status/2015883857489522876) 关于 LLM 编码陷阱的总结。
 
 [English](./README.md) | 简体中文
 
@@ -98,7 +98,9 @@ LLM 经常默默选择一种解释然后执行。这个原则强制明确推理�
 
 ## 安装
 
-**选项 A：Claude Code 插件（推荐）**
+### Claude
+
+**Claude Code 插件（推荐）**
 
 在 Claude Code 中，首先添加插件市场：
 ```
@@ -112,7 +114,7 @@ LLM 经常默默选择一种解释然后执行。这个原则强制明确推理�
 
 这会将指南安装为 Claude Code 插件，使其在你所有项目中可用。
 
-**选项 B：CLAUDE.md（按项目）**
+**CLAUDE.md（按项目）**
 
 新项目：
 ```bash
@@ -125,9 +127,29 @@ echo "" >> CLAUDE.md
 curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
 ```
 
-## 在 Cursor 中使用
+### Codex
 
-本仓库包含一个已提交的 Cursor 项目规则 ([`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc))，因此在 Cursor 中打开项目时同样适用这些指南。详情请参见 **[CURSOR.md](CURSOR.md)**，包括如何在其他项目中使用该规则，以及它与 Claude Code 的关系。
+Codex 目前不能像 Claude Code 一样直接安装这个仓库作为插件。本仓库提供的是 Codex 原生的项目指令和可复用 skill：
+
+- [`AGENTS.md`](AGENTS.md)：Codex 项目级指令
+- [`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md)：可复用的 Codex skill
+- [`skills/karpathy-guidelines/agents/openai.yaml`](skills/karpathy-guidelines/agents/openai.yaml)：Codex skill UI 元数据
+
+如果只想在某个项目中使用，把 [`AGENTS.md`](AGENTS.md) 复制到项目根目录，或合并到已有的 `AGENTS.md`。
+
+如果你的 Codex 安装包含 skill installer，也可以把这个指南安装为可复用 skill：
+
+```bash
+python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
+  --repo forrestchang/andrej-karpathy-skills \
+  --path skills/karpathy-guidelines
+```
+
+安装后重启 Codex。详情请参见 **[CODEX.md](CODEX.md)**。
+
+### Cursor
+
+本仓库包含一个已提交的 Cursor 项目规则 ([`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc))，因此在 Cursor 中打开项目时同样适用这些指南。要在其他项目中使用，把该文件复制到目标项目的 `.cursor/rules/` 目录。详情请参见 **[CURSOR.md](CURSOR.md)**。
 
 ## 核心洞察
 

--- a/skills/karpathy-guidelines/agents/openai.yaml
+++ b/skills/karpathy-guidelines/agents/openai.yaml
@@ -1,0 +1,10 @@
+# Codex UI metadata for the reusable karpathy-guidelines skill.
+# Keep this file lightweight; the behavioral instructions live in SKILL.md.
+interface:
+  display_name: "Karpathy Guidelines"
+  short_description: "Keep coding agents simple, surgical, and verified"
+  default_prompt: "Use $karpathy-guidelines to make this code change with clear assumptions, minimal scope, and verification."
+  brand_color: "#0F766E"
+
+policy:
+  allow_implicit_invocation: true


### PR DESCRIPTION
1. Add AGENTS.md so Codex applies the Karpathy guidelines as project-level instructions when working in this repository.

2. Document Codex usage in README.md, README.zh.md, and CODEX.md, including direct skill installation and per-project AGENTS.md usage.

3. Add Codex skill UI metadata in skills/karpathy-guidelines/agents/openai.yaml so the reusable skill has a clear display name, description, and starter prompt.

4. Update Cursor documentation to describe the Claude Code, Codex, and Cursor integration paths together and keep contributor sync guidance current.