### PR TITLE
Add OpenClaw plugin manifest

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,0 +1,12 @@
+{
+  "id": "karpathy-guidelines",
+  "name": "Karpathy Guidelines",
+  "description": "Behavioral guidelines to reduce common LLM coding mistakes, derived from Andrej Karpathy's observations on LLM coding pitfalls.",
+  "skills": [
+    "./skills"
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `openclaw.plugin.json` manifest so the `karpathy-guidelines` skill can be installed directly in [OpenClaw](https://openclaw.ai) via `openclaw plugins install`
- The manifest points to the existing `./skills` directory, so no changes to the skill content itself

## Usage

```sh
openclaw plugins install forrestchang/andrej-karpathy-skills
# or from local clone
openclaw plugins install --link ./andrej-karpathy-skills
```

## Test plan

- [ ] `openclaw plugins install <path>` picks up the manifest and registers the `karpathy-guidelines` skill
- [ ] `/karpathy-guidelines` skill appears and injects the coding guidelines into context