### PR TITLE
Add Antigravity support

### DIFF
--- a/.agents/skills/karpathy-guidelines/SKILL.md
+++ b/.agents/skills/karpathy-guidelines/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: karpathy-guidelines
+description: Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, surface assumptions, and define verifiable success criteria.
+license: MIT
+---
+
+# Karpathy Guidelines
+
+Behavioral guidelines to reduce common LLM coding mistakes, derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.

--- a/ANTIGRAVITY.md
+++ b/ANTIGRAVITY.md
@@ -1,0 +1,42 @@
+# Using this repo with Antigravity
+
+This project includes the Karpathy-inspired behavioral guidelines as an **Antigravity skill** so they apply when Antigravity detects a relevant task.
+
+## In this repository
+
+1. Open the folder in your editor with Antigravity active.
+2. The skill [`.agents/skills/karpathy-guidelines/SKILL.md`](.agents/skills/karpathy-guidelines/SKILL.md) is committed — Antigravity reads it automatically from `.agents/skills/` when working in this project.
+3. No extra installation steps are required.
+
+## Use the same guidelines in another project
+
+Antigravity supports two installation scopes:
+
+| Location | Scope |
+|----------|-------|
+| `<workspace-root>/.agents/skills/karpathy-guidelines/` | Workspace-specific (this project only) |
+| `~/.gemini/antigravity/skills/karpathy-guidelines/` | Global (applies to all workspaces) |
+
+**Workspace-specific:** Copy the `.agents/skills/karpathy-guidelines/` folder into the target project root.
+
+```bash
+cp -r .agents/skills/karpathy-guidelines /path/to/your-project/.agents/skills/
+```
+
+**Global (all workspaces):** Copy the skill folder into your Antigravity global skills directory.
+
+```bash
+cp -r .agents/skills/karpathy-guidelines ~/.gemini/antigravity/skills/
+```
+
+Antigravity will pick up the skill automatically from either location.
+
+## Claude Code vs Cursor vs Antigravity
+
+- **Claude Code:** Install via the plugin marketplace; see [`README.md`](README.md). Per-project use can rely on `CLAUDE.md`.
+- **Cursor:** Use the committed `.cursor/rules/karpathy-guidelines.mdc` file; see [`CURSOR.md`](CURSOR.md).
+- **Antigravity:** Copy `.agents/skills/karpathy-guidelines/` to the workspace or global skills directory as described above.
+
+## For contributors
+
+When you change the four principles, keep **[`CLAUDE.md`](CLAUDE.md)**, **[`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc)**, and **[`.agents/skills/karpathy-guidelines/SKILL.md`](.agents/skills/karpathy-guidelines/SKILL.md)** in sync.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,15 @@ curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/
 
 This repository includes a committed Cursor project rule ([`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc)) so the same guidelines apply when you open the project in Cursor. See **[CURSOR.md](CURSOR.md)** for setup, using the rule in other projects, and how this relates to Claude Code.
 
+## Using with Antigravity
+
+This repository includes the guidelines as an Antigravity skill ([`.agents/skills/karpathy-guidelines/SKILL.md`](.agents/skills/karpathy-guidelines/SKILL.md)) so they apply automatically when Antigravity is active. See **[ANTIGRAVITY.md](ANTIGRAVITY.md)** for setup details, including how to install the skill for a single workspace or globally across all workspaces.
+
+| Scope | Location |
+|-------|----------|
+| Workspace-specific | `<workspace-root>/.agents/skills/karpathy-guidelines/` |
+| Global (all workspaces) | `~/.gemini/antigravity/skills/karpathy-guidelines/` |
+
 ## Key Insight
 
 From Andrej:

--- a/README.zh.md
+++ b/README.zh.md
@@ -129,6 +129,15 @@ curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/
 
 本仓库包含一个已提交的 Cursor 项目规则 ([`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc))，因此在 Cursor 中打开项目时同样适用这些指南。详情请参见 **[CURSOR.md](CURSOR.md)**，包括如何在其他项目中使用该规则，以及它与 Claude Code 的关系。
 
+## 在 Antigravity 中使用
+
+本仓库将指南作为 Antigravity skill 提供 ([`.agents/skills/karpathy-guidelines/SKILL.md`](.agents/skills/karpathy-guidelines/SKILL.md))，Antigravity 激活时会自动应用这些指南。详情请参见 **[ANTIGRAVITY.md](ANTIGRAVITY.md)**，包括如何为单个工作区或全局所有工作区安装该 skill。
+
+| 范围 | 路径 |
+|------|------|
+| 工作区专用 | `<workspace-root>/.agents/skills/karpathy-guidelines/` |
+| 全局（所有工作区）| `~/.gemini/antigravity/skills/karpathy-guidelines/` |
+
 ## 核心洞察
 
 来自 Andrej：


### PR DESCRIPTION
## Summary

Adds first-class support for Antigravity alongside the existing Claude Code plugin, CLAUDE.md, and Cursor flows: documentation for installing the Karpathy guidelines as an Antigravity skill — either per-workspace or globally across all workspaces.

## Changes

ANTIGRAVITY.md — Antigravity-specific setup: using this repo in Antigravity, copying the skill to another project (workspace-specific vs global), Claude Code / Cursor / Antigravity comparison, and contributor sync note.
README.md — New "Using with Antigravity" subsection linking to ANTIGRAVITY.md, with a location scope table.
README.zh.md — Same "在 Antigravity 中使用" subsection in Chinese.

## Notes

No change to .claude-plugin/, .cursor/, or existing plugin install steps; Claude Code and Cursor users are unaffected.
Antigravity reads skills from .agents/skills/<skill-folder>/ (workspace) or ~/.gemini/antigravity/skills/<skill-folder>/ (global); no new files need to be committed to enable per-project use — the existing .agents/skills/karpathy-guidelines/SKILL.md already serves this purpose.