### PR TITLE
Add Restate Ambiguity, Search Before Building principle

### DIFF
--- a/.cursor/rules/karpathy-guidelines.mdc
+++ b/.cursor/rules/karpathy-guidelines.mdc
@@ -9,6 +9,12 @@ Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-s
 
 **Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
 
+## 0. Restate Ambiguity, Search Before Building
+
+When the user's request has any ambiguity, restate the requirement in your own words before acting.
+
+Before answering from memory or implementing from scratch, name the domain and search existing prior art — methodologies, frameworks, libraries, papers — and bring that specialist knowledge in. Use GitHub and the wider community: **99% of the time, find a mature solution and adapt it — don't build from zero.** Search package registries, official docs, and established repos first. Only when an honest search comes up empty, apply first principles: reframe the requirement from scratch and re-examine whether existing solutions can solve the cleaner problem.
+
 ## 1. Think Before Coding
 
 **Don't assume. Don't hide confusion. Surface tradeoffs.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,12 @@ Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-s
 
 **Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
 
+## 0. Restate Ambiguity, Search Before Building
+
+When the user's request has any ambiguity, restate the requirement in your own words before acting.
+
+Before answering from memory or implementing from scratch, name the domain and search existing prior art — methodologies, frameworks, libraries, papers — and bring that specialist knowledge in. Use GitHub and the wider community: **99% of the time, find a mature solution and adapt it — don't build from zero.** Search package registries, official docs, and established repos first. Only when an honest search comes up empty, apply first principles: reframe the requirement from scratch and re-examine whether existing solutions can solve the cleaner problem.
+
 ## 1. Think Before Coding
 
 **Don't assume. Don't hide confusion. Surface tradeoffs.**

--- a/README.md
+++ b/README.md
@@ -20,16 +20,29 @@ From Andrej's post:
 
 ## The Solution
 
-Four principles in one file that directly address these issues:
+Five principles in one file that directly address these issues:
 
 | Principle | Addresses |
 |-----------|-----------|
+| **Restate Ambiguity, Search Before Building** | Silent assumptions on ambiguous requests, reinventing what already exists |
 | **Think Before Coding** | Wrong assumptions, hidden confusion, missing tradeoffs |
 | **Simplicity First** | Overcomplication, bloated abstractions |
 | **Surgical Changes** | Orthogonal edits, touching code you shouldn't |
 | **Goal-Driven Execution** | Leverage through tests-first, verifiable success criteria |
 
-## The Four Principles in Detail
+## The Five Principles in Detail
+
+### 0. Restate Ambiguity, Search Before Building
+
+**Restate when unclear. Search before reinventing.**
+
+LLMs often run with one interpretation of an ambiguous request and reimplement what already exists as a one-line library call. This principle forces a pause and a search:
+
+- **Restate the requirement** — When the request is ambiguous, echo it back in your own words before acting
+- **Name the domain** — State what kind of problem this is before solving
+- **Search prior art** — Methodologies, frameworks, libraries, papers. Cite specific names, not vague gestures
+- **Adapt, don't rebuild** — 99% of the time a mature solution exists; find it and adapt with the smallest possible delta
+- **First principles is a fallback** — Only when an honest search comes up empty: reframe the requirement, drop accidental constraints, then search again
 
 ### 1. Think Before Coding
 

--- a/skills/karpathy-guidelines/SKILL.md
+++ b/skills/karpathy-guidelines/SKILL.md
@@ -10,6 +10,12 @@ Behavioral guidelines to reduce common LLM coding mistakes, derived from [Andrej
 
 **Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
 
+## 0. Restate Ambiguity, Search Before Building
+
+When the user's request has any ambiguity, restate the requirement in your own words before acting.
+
+Before answering from memory or implementing from scratch, name the domain and search existing prior art — methodologies, frameworks, libraries, papers — and bring that specialist knowledge in. Use GitHub and the wider community: **99% of the time, find a mature solution and adapt it — don't build from zero.** Search package registries, official docs, and established repos first. Only when an honest search comes up empty, apply first principles: reframe the requirement from scratch and re-examine whether existing solutions can solve the cleaner problem.
+
 ## 1. Think Before Coding
 
 **Don't assume. Don't hide confusion. Surface tradeoffs.**


### PR DESCRIPTION
## Summary

Adds **§0. Restate Ambiguity, Search Before Building** as a meta-principle running before the existing four. Sections 1–4 are unchanged.

## What it adds

- Restate ambiguous requests in your own words before acting
- Name the domain and search prior art (libraries, frameworks, papers) before implementing from memory or scratch
- 99% of the time, adapt a mature solution rather than build from zero
- First-principles reasoning as a fallback only when an honest search comes up empty

## Not redundant with §1

§1 (*Think Before Coding*) describes what to do when the LLM has already noticed ambiguity. §0 makes the first move explicit: echo the request back to the user *before* acting, so the LLM doesn't silently pick an interpretation, execute, and only surface the assumption after wrong work is done.

## Why search-before-building belongs here

A failure mode every LLM coding user has seen, even if Karpathy's post doesn't call it out directly: reimplementing 200 lines of date parsing, retry logic, or a graph algorithm that exists as a one-line import. Same shape as the other principles — make the implicit step (*name the domain, search first*) explicit and required.

## Scope kept small

- `CLAUDE.md` — adds §0
- `README.md` — principle count 4→5, table row, detail section in the matching style of §1–§4
- `README.zh.md` and `EXAMPLES.md` intentionally not updated to keep this PR reviewable; happy to follow up if the principle is accepted

Numbered §0 (rather than renumbering 1→2, etc.) so existing principle numbers stay stable for external references.