### PR TITLE
docs(skill): link EXAMPLES.md from SKILL.md so progressive disclosure can pick it up

### DIFF
--- a/skills/karpathy-guidelines/SKILL.md
+++ b/skills/karpathy-guidelines/SKILL.md
@@ -65,3 +65,7 @@ For multi-step tasks, state a brief plan:
 ```
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+For worked examples (anti-pattern → fix) of each principle, see [`EXAMPLES.md`](../../EXAMPLES.md).


### PR DESCRIPTION
## Summary

`EXAMPLES.md` (15KB of worked anti-pattern → fix examples) lives at the repo root but `skills/karpathy-guidelines/SKILL.md` doesn't reference it. Per Anthropic's Agent Skills [progressive-disclosure spec](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview), Claude Code only loads files into context that are linked from `SKILL.md`. That means the worked examples in `EXAMPLES.md` are currently never auto-loaded when the skill activates — even though they're the most concrete value-add the repo offers.

This PR adds a one-line reference at the end of `SKILL.md`:

\`\`\`md
For worked examples (anti-pattern → fix) of each principle, see [\`EXAMPLES.md\`](../../EXAMPLES.md).
\`\`\`

## Why this is the minimal change

- Doesn't move `EXAMPLES.md` (preserves any external links to it)
- Doesn't touch `CLAUDE.md`, `CURSOR.md`, `README.md`, or `README.zh.md`
- Single insertion at the end of \`SKILL.md\`, no edits to existing content

## Effect

When Claude Code (or any agent following the open skill standard) loads \`karpathy-guidelines\` and the user asks a question that maps to one of the four principles, the agent can now follow the link and pull in the relevant worked example. Without this PR, agents only see the abstract principles, not the illustrative code.

## Test plan
- [ ] Verify the relative path \`../../EXAMPLES.md\` resolves correctly from \`skills/karpathy-guidelines/SKILL.md\`
- [ ] Optional: load the skill in Claude Code and confirm \`EXAMPLES.md\` is now discoverable