### PR TITLE
Clean up README: English-only, clarify attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Karpathy-Inspired Claude Code Guidelines
 
-> Check out my new project [Multica](https://github.com/multica-ai/multica) — an open-source platform for running and managing coding agents with reusable skills.
->
-> Follow me on X: [https://x.com/jiayuan_jy](https://x.com/jiayuan_jy)
+> Forked from [multica-ai/andrej-karpathy-skills](https://github.com/multica-ai/andrej-karpathy-skills).
 
 A single `CLAUDE.md` file to improve Claude Code behavior, derived from [Andrej Karpathy's January 2026 post on X](https://x.com/karpathy/status/2015883857489522876) documenting LLM coding pitfalls he observed during intensive agentic coding sessions.
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@
 >
 > Follow me on X: [https://x.com/jiayuan_jy](https://x.com/jiayuan_jy)
 
-A single `CLAUDE.md` file to improve Claude Code behavior, derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.
-
-English | [简体中文](./README.zh.md)
+A single `CLAUDE.md` file to improve Claude Code behavior, derived from [Andrej Karpathy's January 2026 post on X](https://x.com/karpathy/status/2015883857489522876) documenting LLM coding pitfalls he observed during intensive agentic coding sessions.
 
 ## The Problems
 


### PR DESCRIPTION
## Summary

- Removes the `English | 简体中文` language toggle (English-only cleanup)
- Removes the self-promotional Multica/X block at the top
- Updates the Karpathy attribution to specify January 2026 as the date of his original X post and adds context about intensive agentic coding sessions

## Test plan

- [ ] Verify README renders correctly with no Chinese text or broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)