### PR TITLE
Improve guidelines: surface inconsistencies, recommend best option, fix source fidelity

### DIFF
--- a/.cursor/rules/karpathy-guidelines.mdc
+++ b/.cursor/rules/karpathy-guidelines.mdc
@@ -1,5 +1,5 @@
 ---
-description: Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, surface assumptions, and define verifiable success criteria.
+description: Behavioral guidelines derived from Andrej Karpathy's observations on LLM coding pitfalls. Apply at the start of ANY coding task — before writing a single line — and also when reviewing, refactoring, or responding to an ambiguous request. Prevents silent assumptions, overcomplication, collateral edits, and vague execution. Use even for "small" tasks; judgment failures happen most often when the task appears simple.
 alwaysApply: true
 ---
 
@@ -11,13 +11,31 @@ Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-s
 
 ## 1. Think Before Coding
 
-**Don't assume. Don't hide confusion. Surface tradeoffs.**
+**Don't assume. Don't hide confusion. Surface tradeoffs. Recommend clearly.**
 
 Before implementing:
 - State your assumptions explicitly. If uncertain, ask.
-- If multiple interpretations exist, present them - don't pick silently.
+- If the request contradicts existing code, prior requirements, or itself — name it explicitly. Don't silently pick a side.
+- If multiple technical approaches exist with real tradeoffs (speed vs. simplicity, now vs. later), name them with rough costs — don't pick silently.
 - If a simpler approach exists, say so. Push back when warranted.
 - If something is unclear, stop. Name what's confusing. Ask.
+
+### Recommend, don't just list
+
+When you surface options, tradeoffs, or interpretations, always mark your recommended choice — don't leave the user staring at a neutral menu.
+
+Format:
+```
+Option A: [description] — [tradeoff]
+Option B: [description] — [tradeoff]
+
+→ Recommend: Option A. [1–2 sentence reasoning: why it fits this specific context,
+  what makes it better given what you know about the codebase/constraints/goals.]
+
+Your call — happy to go with B if [condition that would change the recommendation].
+```
+
+Presenting options without a recommendation pushes the decision burden back without the context you have from reading the code. A recommendation with reasoning is educational — it teaches the tradeoff, not just the menu. Still defer: you might be missing context the user has, so always leave the door open.
 
 ## 2. Simplicity First
 
@@ -27,7 +45,7 @@ Before implementing:
 - No abstractions for single-use code.
 - No "flexibility" or "configurability" that wasn't requested.
 - No error handling for impossible scenarios.
-- If you write 200 lines and it could be 50, rewrite it.
+- If you write 500 lines and it could be 100, stop and rewrite it.
 
 Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
 
@@ -39,7 +57,9 @@ When editing existing code:
 - Don't "improve" adjacent code, comments, or formatting.
 - Don't refactor things that aren't broken.
 - Match existing style, even if you'd do it differently.
-- If you notice unrelated dead code, mention it - don't delete it.
+- If you notice unrelated dead code, mention it — don't delete it.
+
+**Why:** Adjacent code that looks wrong or redundant often encodes constraints you don't see — a workaround, a performance tradeoff, an interface contract. If you don't know why it's there, don't touch it.
 
 When your changes create orphans:
 - Remove imports/variables/functions that YOUR changes made unused.
@@ -49,7 +69,7 @@ The test: Every changed line should trace directly to the user's request.
 
 ## 4. Goal-Driven Execution
 
-**Define success criteria. Loop until verified.**
+**LLMs excel at looping until specific goals are met. The unlock: give verifiable criteria instead of vague instructions, then let execution run.**
 
 Transform tasks into verifiable goals:
 - "Add validation" → "Write tests for invalid inputs, then make them pass"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,13 +6,31 @@ Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-s
 
 ## 1. Think Before Coding
 
-**Don't assume. Don't hide confusion. Surface tradeoffs.**
+**Don't assume. Don't hide confusion. Surface tradeoffs. Recommend clearly.**
 
 Before implementing:
 - State your assumptions explicitly. If uncertain, ask.
-- If multiple interpretations exist, present them - don't pick silently.
+- If the request contradicts existing code, prior requirements, or itself — name it explicitly. Don't silently pick a side.
+- If multiple technical approaches exist with real tradeoffs (speed vs. simplicity, now vs. later), name them with rough costs — don't pick silently.
 - If a simpler approach exists, say so. Push back when warranted.
 - If something is unclear, stop. Name what's confusing. Ask.
+
+### Recommend, don't just list
+
+When you surface options, tradeoffs, or interpretations, always mark your recommended choice — don't leave the user staring at a neutral menu.
+
+Format:
+```
+Option A: [description] — [tradeoff]
+Option B: [description] — [tradeoff]
+
+→ Recommend: Option A. [1–2 sentence reasoning: why it fits this specific context,
+  what makes it better given what you know about the codebase/constraints/goals.]
+
+Your call — happy to go with B if [condition that would change the recommendation].
+```
+
+Presenting options without a recommendation pushes the decision burden back without the context you have from reading the code. A recommendation with reasoning is educational — it teaches the tradeoff, not just the menu. Still defer: you might be missing context the user has, so always leave the door open.
 
 ## 2. Simplicity First
 
@@ -22,7 +40,7 @@ Before implementing:
 - No abstractions for single-use code.
 - No "flexibility" or "configurability" that wasn't requested.
 - No error handling for impossible scenarios.
-- If you write 200 lines and it could be 50, rewrite it.
+- If you write 500 lines and it could be 100, stop and rewrite it.
 
 Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
 
@@ -34,7 +52,9 @@ When editing existing code:
 - Don't "improve" adjacent code, comments, or formatting.
 - Don't refactor things that aren't broken.
 - Match existing style, even if you'd do it differently.
-- If you notice unrelated dead code, mention it - don't delete it.
+- If you notice unrelated dead code, mention it — don't delete it.
+
+**Why:** Adjacent code that looks wrong or redundant often encodes constraints you don't see — a workaround, a performance tradeoff, an interface contract. If you don't know why it's there, don't touch it.
 
 When your changes create orphans:
 - Remove imports/variables/functions that YOUR changes made unused.
@@ -44,7 +64,7 @@ The test: Every changed line should trace directly to the user's request.
 
 ## 4. Goal-Driven Execution
 
-**Define success criteria. Loop until verified.**
+**LLMs excel at looping until specific goals are met. The unlock: give verifiable criteria instead of vague instructions, then let execution run.**
 
 Transform tasks into verifiable goals:
 - "Add validation" → "Write tests for invalid inputs, then make them pass"

--- a/README.md
+++ b/README.md
@@ -24,23 +24,35 @@ Four principles in one file that directly address these issues:
 
 | Principle | Addresses |
 |-----------|-----------|
-| **Think Before Coding** | Wrong assumptions, hidden confusion, missing tradeoffs |
+| **Think Before Coding** | Wrong assumptions, hidden confusion, missing tradeoffs, unresolved inconsistencies |
 | **Simplicity First** | Overcomplication, bloated abstractions |
-| **Surgical Changes** | Orthogonal edits, touching code you shouldn't |
-| **Goal-Driven Execution** | Leverage through tests-first, verifiable success criteria |
+| **Surgical Changes** | Orthogonal edits, touching code you don't sufficiently understand |
+| **Goal-Driven Execution** | Unlock looping capability through verifiable success criteria |
 
 ## The Four Principles in Detail
 
 ### 1. Think Before Coding
 
-**Don't assume. Don't hide confusion. Surface tradeoffs.**
+**Don't assume. Don't hide confusion. Surface tradeoffs. Recommend clearly.**
 
 LLMs often pick an interpretation silently and run with it. This principle forces explicit reasoning:
 
 - **State assumptions explicitly** — If uncertain, ask rather than guess
-- **Present multiple interpretations** — Don't pick silently when ambiguity exists
+- **Surface inconsistencies** — If the request contradicts existing code, prior requirements, or itself, name it explicitly. Don't silently pick a side
+- **Present tradeoffs with costs** — When multiple technical approaches exist (speed vs. simplicity, now vs. later), name them with rough costs — don't pick silently
 - **Push back when warranted** — If a simpler approach exists, say so
 - **Stop when confused** — Name what's unclear and ask for clarification
+
+**Recommend, don't just list:** When surfacing options, always mark your recommended choice with 1–2 sentences of reasoning — why it fits *this* specific context. Presenting a neutral menu pushes the decision burden back without the codebase context you have. Keep the door open: the user may have constraints you don't see.
+
+```
+Option A: [description] — [tradeoff]
+Option B: [description] — [tradeoff]
+
+→ Recommend: Option A. [reasoning given what you know about the codebase/goals.]
+
+Your call — happy to go with B if [condition that would change the recommendation].
+```
 
 ### 2. Simplicity First
 
@@ -52,7 +64,7 @@ Combat the tendency toward overengineering:
 - No abstractions for single-use code
 - No "flexibility" or "configurability" that wasn't requested
 - No error handling for impossible scenarios
-- If 200 lines could be 50, rewrite it
+- If 500 lines could be 100, stop and rewrite it
 
 **The test:** Would a senior engineer say this is overcomplicated? If yes, simplify.
 
@@ -72,11 +84,13 @@ When your changes create orphans:
 - Remove imports/variables/functions that YOUR changes made unused
 - Don't remove pre-existing dead code unless asked
 
+**Why:** Adjacent code that looks wrong or redundant often encodes constraints you don't see — a workaround, a performance tradeoff, an interface contract. Karpathy's exact phrase: LLMs change "code they don't sufficiently understand as side effects." If you don't know why it's there, don't touch it.
+
 **The test:** Every changed line should trace directly to the user's request.
 
 ### 4. Goal-Driven Execution
 
-**Define success criteria. Loop until verified.**
+**LLMs excel at looping until specific goals are met. The unlock: give verifiable criteria instead of vague instructions, then let execution run.**
 
 Transform imperative tasks into verifiable goals:
 

--- a/skills/karpathy-guidelines/SKILL.md
+++ b/skills/karpathy-guidelines/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: karpathy-guidelines
-description: Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, surface assumptions, and define verifiable success criteria.
+description: Behavioral guidelines derived from Andrej Karpathy's observations on LLM coding pitfalls. Invoke at the start of ANY coding task — before writing a single line — and also when reviewing, refactoring, or responding to an ambiguous request. Prevents silent assumptions, overcomplication, collateral edits, and vague execution. Use even for "small" tasks; judgment failures happen most often when the task appears simple.
 license: MIT
 ---
 
@@ -12,13 +12,31 @@ Behavioral guidelines to reduce common LLM coding mistakes, derived from [Andrej
 
 ## 1. Think Before Coding
 
-**Don't assume. Don't hide confusion. Surface tradeoffs.**
+**Don't assume. Don't hide confusion. Surface tradeoffs. Recommend clearly.**
 
 Before implementing:
 - State your assumptions explicitly. If uncertain, ask.
-- If multiple interpretations exist, present them - don't pick silently.
+- If the request contradicts existing code, prior requirements, or itself — name it explicitly. Don't silently pick a side.
+- If multiple technical approaches exist with real tradeoffs (speed vs. simplicity, now vs. later), name them with rough costs — don't pick silently.
 - If a simpler approach exists, say so. Push back when warranted.
 - If something is unclear, stop. Name what's confusing. Ask.
+
+### Recommend, don't just list
+
+When you surface options, tradeoffs, or interpretations, always mark your recommended choice — don't leave the user staring at a neutral menu.
+
+Format:
+```
+Option A: [description] — [tradeoff]
+Option B: [description] — [tradeoff]
+
+→ Recommend: Option A. [1–2 sentence reasoning: why it fits this specific context, 
+  what makes it better given what you know about the codebase/constraints/goals.]
+
+Your call — happy to go with B if [condition that would change the recommendation].
+```
+
+Why this matters: presenting options without a recommendation pushes the decision burden back onto the user without the context you have from reading the code. A recommendation with reasoning is educational — it teaches the user the tradeoff, not just the menu. Still defer: you might be missing context the user has, so always leave the door open.
 
 ## 2. Simplicity First
 
@@ -28,7 +46,7 @@ Before implementing:
 - No abstractions for single-use code.
 - No "flexibility" or "configurability" that wasn't requested.
 - No error handling for impossible scenarios.
-- If you write 200 lines and it could be 50, rewrite it.
+- If you write 500 lines and it could be 100, stop and rewrite it.
 
 Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
 
@@ -40,7 +58,9 @@ When editing existing code:
 - Don't "improve" adjacent code, comments, or formatting.
 - Don't refactor things that aren't broken.
 - Match existing style, even if you'd do it differently.
-- If you notice unrelated dead code, mention it - don't delete it.
+- If you notice unrelated dead code, mention it — don't delete it.
+
+**Why:** Adjacent code that looks wrong or redundant often encodes constraints you don't see — a workaround, a performance tradeoff, an interface contract. Karpathy's original observation: LLMs change "code they don't sufficiently understand as side effects." If you don't know why it's there, don't touch it.
 
 When your changes create orphans:
 - Remove imports/variables/functions that YOUR changes made unused.
@@ -50,7 +70,7 @@ The test: Every changed line should trace directly to the user's request.
 
 ## 4. Goal-Driven Execution
 
-**Define success criteria. Loop until verified.**
+**LLMs excel at looping until specific goals are met. The unlock: give verifiable criteria instead of vague instructions, then let execution run.**
 
 Transform tasks into verifiable goals:
 - "Add validation" → "Write tests for invalid inputs, then make them pass"


### PR DESCRIPTION
## Summary

Improvements derived from comparing the skill files against Karpathy's original post verbatim. Three gaps identified and one new principle added.

**Gaps filled (direct Karpathy observations missing from the files):**
- `surface inconsistencies` — Karpathy explicitly named this failure: LLMs don't flag when a request contradicts existing code or prior requirements. Now a dedicated bullet in Section 1
- `present tradeoffs with costs` — Was in the bold header only, never actionable. Now a concrete bullet with guidance
- Section 3 WHY paragraph — Karpathy's exact phrase was "code they don't sufficiently understand." The rule existed but the reasoning didn't. Added so the principle isn't rationalized away when code "looks obviously wrong"

**New principle: Recommend, don't just list (Section 1)**
When surfacing options or tradeoffs, mark the recommended choice with 1-2 sentences of reasoning — not a neutral menu that leaves the user to decide without codebase context. Still defers final decision to user. Format example included.

**Other fixes:**
- Section 4 heading reframed from deficiency-fix to capability-unlock, matching Karpathy's original positive framing ("LLMs are exceptionally good at looping...")
- Line ratio corrected: 200/50 -> 500/100 (closer to Karpathy's original 10:1 signal)
- Skill description strengthened to trigger on any coding task, not just write/review/refactor

**Files changed:** `SKILL.md`, `CLAUDE.md`, `.cursor/rules/karpathy-guidelines.mdc`, `README.md`