### PR TITLE
fix(marketplace): drop unknown 'id' field from manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,5 @@
 {
   "name": "karpathy-skills",
-  "id": "karpathy-skills",
   "owner": {
     "name": "forrestchang"
   },


### PR DESCRIPTION
## Summary

`claude plugin validate --strict` (Claude Code 2.1.145) flags the top-level `id` field in `.claude-plugin/marketplace.json` as unknown:

```
⚠ Found 1 warning:
  ❯ id: Unknown field 'id'. Claude Code ignores it at load time.
```

The `name` field already serves as the marketplace identifier; `id` is dropped at load time and contributes nothing.

## Change

Remove line 3 (`"id": "karpathy-skills"`).

## Verify

```sh
claude plugin validate <repo-root>
# → ✔ Validation passed
```