### PR TITLE
Add Codex support and plugin packaging

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "karpathy-skills",
+  "interface": {
+    "displayName": "Karpathy Skills"
+  },
+  "plugins": [
+    {
+      "name": "andrej-karpathy-skills",
+      "source": {
+        "source": "local",
+        "path": "./plugins/andrej-karpathy-skills"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coding"
+    }
+  ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "andrej-karpathy-skills",
+  "version": "1.0.0",
+  "description": "Behavioral guidelines to reduce common LLM coding mistakes, derived from Andrej Karpathy's observations on LLM coding pitfalls",
+  "author": {
+    "name": "forrestchang"
+  },
+  "homepage": "https://github.com/forrestchang/andrej-karpathy-skills",
+  "repository": "https://github.com/forrestchang/andrej-karpathy-skills",
+  "license": "MIT",
+  "keywords": [
+    "guidelines",
+    "best-practices",
+    "coding",
+    "karpathy"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Karpathy Guidelines",
+    "shortDescription": "Keep coding agents simple, surgical, and verified",
+    "longDescription": "Use Karpathy-inspired coding guardrails to surface assumptions, avoid overengineering, keep diffs surgical, and verify results.",
+    "developerName": "forrestchang",
+    "category": "Coding",
+    "capabilities": [
+      "Interactive"
+    ],
+    "defaultPrompt": [
+      "Use Karpathy Guidelines while writing, reviewing, or refactoring code"
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md
+
+Behavioral guidelines to reduce common LLM coding mistakes. Codex reads this file as repository-level guidance when working in this project.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" -> "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" -> "Write a test that reproduces it, then make it pass"
+- "Refactor X" -> "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] -> verify: [check]
+2. [Step] -> verify: [check]
+3. [Step] -> verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/CODEX.md
+++ b/CODEX.md
@@ -14,7 +14,14 @@ This project includes **Codex repository instructions** so the Karpathy-inspired
 
 **Reusable skill:** Copy or symlink [`skills/karpathy-guidelines`](skills/karpathy-guidelines) into your Codex skills directory if you want to invoke it explicitly as `$karpathy-guidelines`.
 
-**Codex plugin:** Plugin distribution is intentionally handled separately from this baseline Codex support so the project guidance, reusable skill, and plugin packaging can stay easy to review.
+**Codex plugin:** Add this repo as a Codex plugin marketplace:
+
+```bash
+codex plugin marketplace add forrestchang/andrej-karpathy-skills
+codex plugin add andrej-karpathy-skills@karpathy-skills
+```
+
+This exposes the plugin package under [`plugins/andrej-karpathy-skills`](plugins/andrej-karpathy-skills). Keep its skill copy aligned with the root [`skills/karpathy-guidelines`](skills/karpathy-guidelines) source when changing the four principles.
 
 ## Claude Code vs Codex vs Cursor
 
@@ -24,4 +31,4 @@ This project includes **Codex repository instructions** so the Karpathy-inspired
 
 ## For contributors
 
-When you change the four principles, keep **[`AGENTS.md`](AGENTS.md)**, **[`CLAUDE.md`](CLAUDE.md)**, **[`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc)**, and **[`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md)** in sync.
+When you change the four principles, keep **[`AGENTS.md`](AGENTS.md)**, **[`CLAUDE.md`](CLAUDE.md)**, **[`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc)**, **[`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md)**, and the packaged Codex plugin skill in sync.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,27 @@
+# Using this repo with Codex
+
+This project includes **Codex repository instructions** so the Karpathy-inspired behavioral guidelines apply automatically when Codex works here.
+
+## In this repository
+
+1. Open the folder in Codex.
+2. The root [`AGENTS.md`](AGENTS.md) file is committed, so Codex loads it as project guidance.
+3. The reusable skill remains available at [`skills/karpathy-guidelines`](skills/karpathy-guidelines).
+
+## Use the same guidelines in another project
+
+**Codex project instructions (recommended):** Copy [`AGENTS.md`](AGENTS.md) into that project's root, or merge its contents into an existing `AGENTS.md`.
+
+**Reusable skill:** Copy or symlink [`skills/karpathy-guidelines`](skills/karpathy-guidelines) into your Codex skills directory if you want to invoke it explicitly as `$karpathy-guidelines`.
+
+**Codex plugin:** Plugin distribution is intentionally handled separately from this baseline Codex support so the project guidance, reusable skill, and plugin packaging can stay easy to review.
+
+## Claude Code vs Codex vs Cursor
+
+- **Claude Code:** Install via the plugin marketplace and [`README.md`](README.md) instructions; the plugin exposes the skill from this repo. Per-project use can also rely on `CLAUDE.md`.
+- **Codex:** Use the root [`AGENTS.md`](AGENTS.md) file for project guidance, or install the reusable skill from [`skills/karpathy-guidelines`](skills/karpathy-guidelines).
+- **Cursor:** Use the committed `.cursor/rules/` file described in [`CURSOR.md`](CURSOR.md).
+
+## For contributors
+
+When you change the four principles, keep **[`AGENTS.md`](AGENTS.md)**, **[`CLAUDE.md`](CLAUDE.md)**, **[`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc)**, and **[`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md)** in sync.

--- a/CURSOR.md
+++ b/CURSOR.md
@@ -12,17 +12,20 @@ This project includes a **Cursor project rule** so the Karpathy-inspired behavio
 
 **Cursor (recommended):** Copy `.cursor/rules/karpathy-guidelines.mdc` into that project’s `.cursor/rules/` directory (create the folders if needed). Adjust or merge with existing rules as you like.
 
+**Codex:** Copy [`AGENTS.md`](AGENTS.md) into that project root so Codex loads the guidelines as repository-level instructions. See [`CODEX.md`](CODEX.md).
+
 **Other tools:** If a stack only supports a root instruction file, copy [`CLAUDE.md`](CLAUDE.md) into that project instead (or merge its contents into your existing instructions).
 
 ## Optional: personal Agent Skills
 
 If you want the same content as a reusable skill under `~/.cursor/skills`, use [`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md). You can copy or symlink it into your personal skills directory; use whatever layout you use for other skills.
 
-## Claude Code vs Cursor
+## Claude Code vs Codex vs Cursor
 
 - **Claude Code:** Install via the plugin marketplace and [`README.md`](README.md) instructions; the plugin exposes the skill from this repo. Per-project use can also rely on `CLAUDE.md`.
+- **Codex:** Use the root [`AGENTS.md`](AGENTS.md) file for project guidance, or install the reusable skill from [`skills/karpathy-guidelines`](skills/karpathy-guidelines).
 - **Cursor:** Use the committed `.cursor/rules/` file as described above. Cursor does not read `.claude-plugin/` or `CLAUDE.md` by default.
 
 ## For contributors
 
-When you change the four principles, keep **[`CLAUDE.md`](CLAUDE.md)** and **[`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc)** in sync. If the published skill/plugin text should match, update **[`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md)** as well.
+When you change the four principles, keep **[`AGENTS.md`](AGENTS.md)**, **[`CLAUDE.md`](CLAUDE.md)**, and **[`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc)** in sync. If the published skill/plugin text should match, update **[`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md)** as well.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,21 @@ Then install the plugin:
 
 This installs the guidelines as a Claude Code plugin, making the skill available across all your projects.
 
-**Option B: CLAUDE.md (per-project)**
+**Option B: Codex Plugin**
+
+From within Codex, add the marketplace:
+```bash
+codex plugin marketplace add forrestchang/andrej-karpathy-skills
+```
+
+Then install the plugin:
+```bash
+codex plugin add andrej-karpathy-skills@karpathy-skills
+```
+
+This installs the Codex plugin from this repo so the reusable skill is available without copying files manually.
+
+**Option C: CLAUDE.md (per-project)**
 
 New project:
 ```bash
@@ -125,7 +139,7 @@ echo "" >> CLAUDE.md
 curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
 ```
 
-**Option C: Codex project instructions**
+**Option D: Codex project instructions**
 
 Copy [`AGENTS.md`](AGENTS.md) into a project root so Codex loads the guidelines as repository-level guidance. The reusable skill in [`skills/karpathy-guidelines`](skills/karpathy-guidelines) also includes Codex metadata for explicit `$karpathy-guidelines` use.
 

--- a/README.md
+++ b/README.md
@@ -125,9 +125,17 @@ echo "" >> CLAUDE.md
 curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
 ```
 
+**Option C: Codex project instructions**
+
+Copy [`AGENTS.md`](AGENTS.md) into a project root so Codex loads the guidelines as repository-level guidance. The reusable skill in [`skills/karpathy-guidelines`](skills/karpathy-guidelines) also includes Codex metadata for explicit `$karpathy-guidelines` use.
+
 ## Using with Cursor
 
 This repository includes a committed Cursor project rule ([`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc)) so the same guidelines apply when you open the project in Cursor. See **[CURSOR.md](CURSOR.md)** for setup, using the rule in other projects, and how this relates to Claude Code.
+
+## Using with Codex
+
+This repository includes a root **[`AGENTS.md`](AGENTS.md)** file so Codex loads the same Karpathy-inspired behavioral guidelines as repository-level instructions. See **[CODEX.md](CODEX.md)** for setup, using the reusable skill in other projects, and how this relates to Claude Code and Cursor.
 
 ## Key Insight
 
@@ -148,7 +156,7 @@ These guidelines are working if you see:
 
 ## Customization
 
-These guidelines are designed to be merged with project-specific instructions. Add them to your existing `CLAUDE.md` or create a new one.
+These guidelines are designed to be merged with project-specific instructions. Add them to your existing `CLAUDE.md`, `AGENTS.md`, or project rule file as appropriate for your coding agent.
 
 For project-specific rules, add sections like:
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -112,7 +112,21 @@ LLM 经常默默选择一种解释然后执行。这个原则强制明确推理�
 
 这会将指南安装为 Claude Code 插件，使其在你所有项目中可用。
 
-**选项 B：CLAUDE.md（按项目）**
+**选项 B：Codex 插件**
+
+在 Codex 中添加插件市场：
+```bash
+codex plugin marketplace add forrestchang/andrej-karpathy-skills
+```
+
+然后安装插件：
+```bash
+codex plugin add andrej-karpathy-skills@karpathy-skills
+```
+
+这会安装本仓库中的 Codex 插件，让可复用技能无需手动复制文件即可使用。
+
+**选项 C：CLAUDE.md（按项目）**
 
 新项目：
 ```bash
@@ -125,7 +139,7 @@ echo "" >> CLAUDE.md
 curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
 ```
 
-**选项 C：Codex 项目指令**
+**选项 D：Codex 项目指令**
 
 将 [`AGENTS.md`](AGENTS.md) 复制到项目根目录，Codex 就会将这些指南作为仓库级指令加载。[`skills/karpathy-guidelines`](skills/karpathy-guidelines) 中的可复用技能也包含 Codex 元数据，可用于显式调用 `$karpathy-guidelines`。
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -125,9 +125,17 @@ echo "" >> CLAUDE.md
 curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
 ```
 
+**选项 C：Codex 项目指令**
+
+将 [`AGENTS.md`](AGENTS.md) 复制到项目根目录，Codex 就会将这些指南作为仓库级指令加载。[`skills/karpathy-guidelines`](skills/karpathy-guidelines) 中的可复用技能也包含 Codex 元数据，可用于显式调用 `$karpathy-guidelines`。
+
 ## 在 Cursor 中使用
 
 本仓库包含一个已提交的 Cursor 项目规则 ([`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc))，因此在 Cursor 中打开项目时同样适用这些指南。详情请参见 **[CURSOR.md](CURSOR.md)**，包括如何在其他项目中使用该规则，以及它与 Claude Code 的关系。
+
+## 在 Codex 中使用
+
+本仓库包含根目录 **[`AGENTS.md`](AGENTS.md)** 文件，因此 Codex 会将同一套受 Karpathy 启发的行为指南作为仓库级指令加载。详情请参见 **[CODEX.md](CODEX.md)**，包括如何在其他项目中使用可复用技能，以及它与 Claude Code 和 Cursor 的关系。
 
 ## 核心洞察
 
@@ -148,7 +156,7 @@ curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/
 
 ## 定制
 
-这些指南设计用于与项目特定指令合并。将它们添加到你现有的 `CLAUDE.md` 或创建一个新的。
+这些指南设计用于与项目特定指令合并。根据你的编码智能体，将它们添加到现有的 `CLAUDE.md`、`AGENTS.md` 或项目规则文件中。
 
 对于项目特定规则，添加如下章节：
 

--- a/plugins/andrej-karpathy-skills/.codex-plugin/plugin.json
+++ b/plugins/andrej-karpathy-skills/.codex-plugin/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "andrej-karpathy-skills",
+  "version": "1.0.0",
+  "description": "Behavioral guidelines to reduce common LLM coding mistakes, derived from Andrej Karpathy's observations on LLM coding pitfalls",
+  "author": {
+    "name": "forrestchang"
+  },
+  "homepage": "https://github.com/forrestchang/andrej-karpathy-skills",
+  "repository": "https://github.com/forrestchang/andrej-karpathy-skills",
+  "license": "MIT",
+  "keywords": [
+    "guidelines",
+    "best-practices",
+    "coding",
+    "karpathy"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Karpathy Guidelines",
+    "shortDescription": "Keep coding agents simple, surgical, and verified",
+    "longDescription": "Use Karpathy-inspired coding guardrails to surface assumptions, avoid overengineering, keep diffs surgical, and verify results.",
+    "developerName": "forrestchang",
+    "category": "Coding",
+    "capabilities": [
+      "Interactive"
+    ],
+    "defaultPrompt": [
+      "Use Karpathy Guidelines while writing, reviewing, or refactoring code"
+    ]
+  }
+}

--- a/plugins/andrej-karpathy-skills/skills/karpathy-guidelines/SKILL.md
+++ b/plugins/andrej-karpathy-skills/skills/karpathy-guidelines/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: karpathy-guidelines
+description: Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, surface assumptions, and define verifiable success criteria.
+license: MIT
+---
+
+# Karpathy Guidelines
+
+Behavioral guidelines to reduce common LLM coding mistakes, derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.

--- a/plugins/andrej-karpathy-skills/skills/karpathy-guidelines/agents/openai.yaml
+++ b/plugins/andrej-karpathy-skills/skills/karpathy-guidelines/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Karpathy Guidelines"
+  short_description: "Keep coding agents simple, surgical, and verified"
+  default_prompt: "Use $karpathy-guidelines to make this code change with clear assumptions, minimal scope, and verification."
+policy:
+  allow_implicit_invocation: true

--- a/skills/karpathy-guidelines/agents/openai.yaml
+++ b/skills/karpathy-guidelines/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Karpathy Guidelines"
+  short_description: "Keep coding agents simple, surgical, and verified"
+  default_prompt: "Use $karpathy-guidelines to make this code change with clear assumptions, minimal scope, and verification."
+policy:
+  allow_implicit_invocation: true


### PR DESCRIPTION
## Summary

Add first-class Codex support and a working Codex plugin marketplace package while keeping the existing Claude Code and Cursor paths unchanged.

## Changes

- Add `AGENTS.md` for Codex repository-level instructions
- Add `CODEX.md` with Codex setup and contributor guidance
- Add Codex skill UI metadata for `skills/karpathy-guidelines`
- Add Codex marketplace metadata and an installable plugin package under `plugins/andrej-karpathy-skills`
- Document Codex project-instruction and plugin install flows in `README.md`, `README.zh.md`, and `CURSOR.md`

## Notes

- No changes to existing Claude Code plugin behavior
- No changes to Cursor rule behavior
- The packaged plugin includes a copy of the skill because the current Codex marketplace flow discovers installable plugins from `plugins/<name>`
- The packaged skill copy was verified to match the root `skills/karpathy-guidelines/SKILL.md`

## Validation

- Ran `git diff --check`
- Parsed JSON plugin and marketplace manifests with `python3 -m json.tool`
- Parsed Codex `openai.yaml` metadata successfully
- Confirmed root and packaged skill files match with `diff`
- Validated the packaged plugin with `uv run --with pyyaml python ~/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py plugins/andrej-karpathy-skills`
- Tested Codex CLI install flow in a temporary `CODEX_HOME`:
  - `codex plugin marketplace add .`
  - `codex plugin add andrej-karpathy-skills@karpathy-skills`