### PR TITLE
docs: sync SKILL.md closing "working if" paragraph with CLAUDE.md

### DIFF
--- a/skills/karpathy-guidelines/SKILL.md
+++ b/skills/karpathy-guidelines/SKILL.md
@@ -65,3 +65,7 @@ For multi-step tasks, state a brief plan:
 ```
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.


### PR DESCRIPTION
## Summary

`CLAUDE.md` ends with a closing paragraph defining success criteria for the guidelines themselves. `skills/karpathy-guidelines/SKILL.md` was missing it.

This PR appends the same paragraph to `SKILL.md` so both files stay aligned. A user reading `CLAUDE.md` and an assistant loading `SKILL.md` now receive identical guidance.

## Diff repro (before this PR)

```bash
diff CLAUDE.md skills/karpathy-guidelines/SKILL.md
```

Confirmed on v1.0.0 (commit `2c60614`).

## Follow-up suggestion

Long-term, consider generating one file from the other (or having `CLAUDE.md` `@import` the skill body) to prevent future drift.