### PR TITLE
Add MIT LICENSE file (matches license declared in plugin.json + SKILL.md)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jiayuan Zhang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OF OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## What

Adds a root `LICENSE` file containing the canonical MIT Expat license text.

## Why

Both `.claude-plugin/plugin.json` and `skills/karpathy-guidelines/SKILL.md` already declare:

```json
"license": "MIT"
```

```yaml
license: MIT
```

But without an actual `LICENSE` file at the repo root, downstream consumers face legal ambiguity — under default copyright law, code with no license file is "all rights reserved," which contradicts the metadata. This blocks downstream forks/distribution that require formal license verification (e.g. internal SBOM scanners, license-classification pipelines, OSI checkers, GitHub's license auto-detector).

Adding the LICENSE file matches stated intent and unblocks adopters.

## Surgical

This PR touches **one new file**. No other changes — per the repo's own principle #3.

## Copyright attribution

Copyright assigned to **Jiayuan Zhang** (original author per first-commit history, `forrestchang7@gmail.com`). Please correct in review if a different attribution is preferred (e.g. organization, multiple contributors).

---

_Submitted via automated EXTREP pipeline; happy to revise based on maintainer preference._