### PR TITLE
Add usage instructions for VS Code GitHub Copilot in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,23 @@ curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/
 
 This repository includes a committed Cursor project rule ([`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc)) so the same guidelines apply when you open the project in Cursor. See **[CURSOR.md](CURSOR.md)** for setup, using the rule in other projects, and how this relates to Claude Code.
 
+## Using with VS Code GitHub Copilot
+
+Install as a Copilot plugin from the terminal:
+
+```bash
+copilot plugin marketplace add forrestchang/andrej-karpathy-skills
+copilot plugin install andrej-karpathy-skills@karpathy-skills
+```
+
+Once installed, invoke the skill in any Copilot Chat conversation:
+
+```
+/andrej-karpathy-skills:karpathy-guidelines
+```
+
+This makes the guidelines available across all your projects without copying files.
+
 ## Key Insight
 
 From Andrej:

--- a/README.zh.md
+++ b/README.zh.md
@@ -129,6 +129,23 @@ curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/
 
 本仓库包含一个已提交的 Cursor 项目规则 ([`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc))，因此在 Cursor 中打开项目时同样适用这些指南。详情请参见 **[CURSOR.md](CURSOR.md)**，包括如何在其他项目中使用该规则，以及它与 Claude Code 的关系。
 
+## 在 VS Code GitHub Copilot 中使用
+
+从终端安装为 Copilot 插件：
+
+```bash
+copilot plugin marketplace add forrestchang/andrej-karpathy-skills
+copilot plugin install andrej-karpathy-skills@karpathy-skills
+```
+
+安装完成后，在任何 Copilot Chat 对话中调用该技能：
+
+```
+/andrej-karpathy-skills:karpathy-guidelines
+```
+
+无需复制文件，即可在所有项目中使用这些指南。
+
 ## 核心洞察
 
 来自 Andrej：


### PR DESCRIPTION
It worked perfectly on my side 🙂 hope this can help others too! 🙌 
<img width="452" height="40" alt="image" src="https://github.com/user-attachments/assets/3154aa5a-f790-4a7b-98fe-fbda6c45e22c" />
<img width="457" height="27" alt="image" src="https://github.com/user-attachments/assets/fce92a02-03f1-4380-bb28-b75b5b299ce4" />

<img width="446" height="341" alt="image" src="https://github.com/user-attachments/assets/d53274a2-020f-48c2-9988-489320ddba05" />
