### PR TITLE
feat: add Gemini CLI extension support

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,51 @@
+# Using this repo with Gemini CLI
+
+This repository includes a `gemini-extension.json` so the Karpathy-inspired behavioral guidelines can be installed as a [Gemini CLI](https://github.com/google-gemini/gemini-cli) extension.
+
+## Install the extension
+
+```bash
+gemini extensions install https://github.com/multica-ai/andrej-karpathy-skills
+```
+
+This installs the `karpathy-guidelines` skill globally. Once installed, the guidelines are available in every Gemini CLI session.
+
+## Use in another project (local link)
+
+```bash
+git clone https://github.com/multica-ai/andrej-karpathy-skills
+gemini extensions link ./andrej-karpathy-skills
+```
+
+## Verify the skill is loaded
+
+Inside Gemini CLI, run:
+
+```
+/skills list
+```
+
+You should see `karpathy-guidelines` in the output.
+
+## How it works
+
+Gemini CLI reads `gemini-extension.json` at the repository root, then loads agent skills from the `skills/` directory. The `karpathy-guidelines` skill injects the four principles into every session context:
+
+1. **Think Before Coding** — state assumptions, ask before guessing
+2. **Simplicity First** — minimum code that solves the problem
+3. **Surgical Changes** — touch only what the task requires
+4. **Goal-Driven Execution** — define verifiable success criteria
+
+## Claude Code vs Cursor vs Gemini CLI
+
+| Tool | How it works |
+|------|-------------|
+| Claude Code | `/plugin install andrej-karpathy-skills@karpathy-skills` |
+| Cursor | `.cursor/rules/karpathy-guidelines.mdc` (auto-applied) |
+| Gemini CLI | `gemini extensions install <github-url>` |
+
+See **[CLAUDE.md](CLAUDE.md)** and **[CURSOR.md](CURSOR.md)** for those tool's setup instructions.
+
+## For contributors
+
+When you update the four principles, keep [`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md) in sync with [`CLAUDE.md`](CLAUDE.md) and [`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc).

--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/
 
 This repository includes a committed Cursor project rule ([`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc)) so the same guidelines apply when you open the project in Cursor. See **[CURSOR.md](CURSOR.md)** for setup, using the rule in other projects, and how this relates to Claude Code.
 
+## Using with Gemini CLI
+
+This repository includes a `gemini-extension.json` so the same guidelines apply as a [Gemini CLI](https://github.com/google-gemini/gemini-cli) extension. See **[GEMINI.md](GEMINI.md)** for setup, using the extension in other projects, and how this relates to Claude Code and Cursor.
+
 ## Key Insight
 
 From Andrej:

--- a/README.zh.md
+++ b/README.zh.md
@@ -129,6 +129,10 @@ curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/
 
 本仓库包含一个已提交的 Cursor 项目规则 ([`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc))，因此在 Cursor 中打开项目时同样适用这些指南。详情请参见 **[CURSOR.md](CURSOR.md)**，包括如何在其他项目中使用该规则，以及它与 Claude Code 的关系。
 
+## 在 Gemini CLI 中使用
+
+本仓库包含 `gemini-extension.json`，可将相同的指南作为 [Gemini CLI](https://github.com/google-gemini/gemini-cli) 扩展应用。详情请参见 **[GEMINI.md](GEMINI.md)**，包括如何在其他项目中使用该扩展，以及它与 Claude Code 和 Cursor 的关系。
+
 ## 核心洞察
 
 来自 Andrej：

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,6 @@
+{
+  "name": "karpathy-guidelines",
+  "version": "1.0.0",
+  "description": "Andrej Karpathy's behavioral coding guidelines as a Gemini CLI skill",
+  "contextFileName": []
+}


### PR DESCRIPTION
## Summary

Adds first-class Gemini CLI support alongside the existing Claude Code plugin and Cursor rule.

## Changes

- **gemini-extension.json** — extension manifest at repo root. `contextFileName: []` is intentional: prevents GEMINI.md from being injected as raw context into every session; skills/ handles behavioral injection.
- **GEMINI.md** — setup instructions following the CURSOR.md pattern: install command, local-link option, verify step, cross-tool comparison table
- **README.md** — "Using with Gemini CLI" section added after the Cursor section
- **README.zh.md** — Chinese parity

No changes to .claude-plugin/, .cursor/, CLAUDE.md, or skills/karpathy-guidelines/SKILL.md.

## Install

gemini extensions install https://github.com/multica-ai/andrej-karpathy-skills

Tested with Gemini CLI v0.41.2 — gemini extensions validate passes, extension links and lists correctly.

## Notes

- The existing skills/karpathy-guidelines/SKILL.md is already Gemini CLI compatible (valid YAML frontmatter) — no changes needed
- contextFileName: [] is the non-obvious but correct choice; without it Gemini CLI injects GEMINI.md as raw context into every session prompt
