### PR TITLE
fix: update forrestchang→multica-ai references, sync SKILL.md footer, add Codex plugin support

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "andrej-karpathy-skills",
+  "description": "Behavioral guidelines to reduce common LLM coding mistakes, derived from Andrej Karpathy's observations on LLM coding pitfalls",
+  "version": "1.0.0",
+  "author": {
+    "name": "multica-ai"
+  },
+  "license": "MIT",
+  "keywords": ["guidelines", "best-practices", "coding", "karpathy"],
+  "skills": ["./skills/karpathy-guidelines"]
+}

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Strong success criteria let the LLM loop independently. Weak criteria ("make it 
 
 From within Claude Code, first add the marketplace:
 ```
-/plugin marketplace add forrestchang/andrej-karpathy-skills
+/plugin marketplace add multica-ai/andrej-karpathy-skills
 ```
 
 Then install the plugin:
@@ -116,13 +116,13 @@ This installs the guidelines as a Claude Code plugin, making the skill available
 
 New project:
 ```bash
-curl -o CLAUDE.md https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md
+curl -o CLAUDE.md https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/CLAUDE.md
 ```
 
 Existing project (append):
 ```bash
 echo "" >> CLAUDE.md
-curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
+curl https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
 ```
 
 ## Using with Cursor

--- a/README.zh.md
+++ b/README.zh.md
@@ -102,7 +102,7 @@ LLM 经常默默选择一种解释然后执行。这个原则强制明确推理�
 
 在 Claude Code 中，首先添加插件市场：
 ```
-/plugin marketplace add forrestchang/andrej-karpathy-skills
+/plugin marketplace add multica-ai/andrej-karpathy-skills
 ```
 
 然后安装插件：
@@ -116,13 +116,13 @@ LLM 经常默默选择一种解释然后执行。这个原则强制明确推理�
 
 新项目：
 ```bash
-curl -o CLAUDE.md https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md
+curl -o CLAUDE.md https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/CLAUDE.md
 ```
 
 已有项目（追加）：
 ```bash
 echo "" >> CLAUDE.md
-curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
+curl https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
 ```
 
 ## 在 Cursor 中使用

--- a/skills/karpathy-guidelines/SKILL.md
+++ b/skills/karpathy-guidelines/SKILL.md
@@ -65,3 +65,7 @@ For multi-step tasks, state a brief plan:
 ```
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.


### PR DESCRIPTION
## Summary

Three targeted fixes to keep the repo consistent and expand tool compatibility.

### 1. Fix outdated `forrestchang` → `multica-ai` references
**Root Cause:** repo was transferred from `forrestchang/andrej-karpathy-skills` to `multica-ai/andrej-karpathy-skills` but README curl commands and plugin marketplace paths still point to the old org — users running these commands get 404 or clone the wrong fork.

### 2. Sync SKILL.md footer
**Root Cause:** `skills/karpathy-guidelines/SKILL.md` is missing the verification footer present in both `CLAUDE.md` and `.cursor/rules/karpathy-guidelines.mdc`, causing content drift across tool-specific instruction files.

### 3. Add Codex plugin support
**Motivation:** repo already supports Claude Code (`.claude-plugin/`) and Cursor (`.cursor/rules/`) but not Codex CLI. The SKILL.md is already in Codex-compatible format — only the plugin manifest was missing.

## Test Plan / Verification

| Change | Verification |
|--------|-------------|
| README curl URLs | `curl -I https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/CLAUDE.md` returns 200 (was 404 with `forrestchang`) |
| Plugin marketplace path | `multica-ai/andrej-karpathy-skills` is the canonical GitHub path post-transfer |
| SKILL.md footer | Diff against CLAUDE.md footer — verbatim match confirmed |
| Codex plugin.json | Valid JSON, mirrors `.claude-plugin/plugin.json` structure, skills path resolves to `./skills/karpathy-guidelines` |

## Risk / Compatibility

- **Low risk.** All URL changes are strictly repo-rename fixes. No behavioral changes.
- **Backward compatible.** The old `forrestchang` URLs are already broken; this only fixes them.
- **SKILL.md addition** is non-breaking — prepends nothing, changes no existing lines.
- **Codex plugin.json** is additive only; zero impact on existing Claude Code / Cursor workflows.

## Files Changed

- `README.md` — 3 URL fixes
- `README.zh.md` — 3 URL fixes
- `skills/karpathy-guidelines/SKILL.md` — +4 lines (verification footer)
- `.codex-plugin/plugin.json` — new file (Codex plugin manifest)