### PR TITLE
docs: add CodeWhale skill usage

### DIFF
--- a/CODEWHALE.md
+++ b/CODEWHALE.md
@@ -1,0 +1,50 @@
+# Using this repo with CodeWhale
+
+This repository is already structured as a CodeWhale skill package. CodeWhale discovers skills from workspace `skills/` directories, and the reusable guideline skill lives at [`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md).
+
+## Install from GitHub
+
+From CodeWhale:
+
+```
+/skill install github:forrestchang/andrej-karpathy-skills
+```
+
+Then confirm the skill is available:
+
+```
+/skills
+/skill karpathy-guidelines
+```
+
+If CodeWhale asks for trust confirmation for the installed community skill, use:
+
+```
+/skill trust karpathy-guidelines
+```
+
+## Use in this repository
+
+When this repository is the active workspace, CodeWhale can discover the skill from:
+
+```
+skills/karpathy-guidelines/SKILL.md
+```
+
+Do not also copy the same skill into `.agents/skills/` in this repo. CodeWhale checks `.agents/skills` before `skills`, so a duplicate would shadow the canonical skill and create drift risk.
+
+## Why this is a skill, not a plugin
+
+The content is reusable agent behavior: think before coding, prefer simplicity, make surgical changes, and define verifiable success criteria. CodeWhale's skill system is the native fit for that kind of behavior. A plugin wrapper would add packaging surface without adding runtime capability.
+
+CodeWhale's GitHub installer scans downloaded repositories for `SKILL.md` and supports the `skills/<name>/SKILL.md` layout used here, so a separate CodeWhale plugin manifest is unnecessary.
+
+## For contributors
+
+When changing the guideline content, keep these files aligned:
+
+- [`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md) for CodeWhale and other skill-aware agents
+- [`CLAUDE.md`](CLAUDE.md) for per-project Claude Code use
+- [`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc) for Cursor
+
+The CodeWhale documentation in this file should only need updates when install commands or repository layout change.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Karpathy-Inspired Claude Code Guidelines
+# Karpathy-Inspired Agent Coding Guidelines
 
 > Check out my new project [Multica](https://github.com/multica-ai/multica) — an open-source platform for running and managing coding agents with reusable skills.
 >
 > Follow me on X: [https://x.com/jiayuan_jy](https://x.com/jiayuan_jy)
 
-A single `CLAUDE.md` file to improve Claude Code behavior, derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.
+A reusable coding-agent skill, plus tool-specific instruction files, derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.
 
 English | [简体中文](./README.zh.md)
 
@@ -98,7 +98,22 @@ Strong success criteria let the LLM loop independently. Weak criteria ("make it 
 
 ## Install
 
-**Option A: Claude Code Plugin (recommended)**
+**Option A: CodeWhale Skill (recommended for CodeWhale)**
+
+Install from GitHub:
+```
+/skill install github:forrestchang/andrej-karpathy-skills
+```
+
+Then enable or inspect the skill:
+```
+/skill karpathy-guidelines
+/skills
+```
+
+CodeWhale discovers the committed skill directly from [`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md). No CodeWhale plugin wrapper is required. See **[CODEWHALE.md](CODEWHALE.md)** for trust and layout details.
+
+**Option B: Claude Code Plugin**
 
 From within Claude Code, first add the marketplace:
 ```
@@ -112,7 +127,7 @@ Then install the plugin:
 
 This installs the guidelines as a Claude Code plugin, making the skill available across all your projects.
 
-**Option B: CLAUDE.md (per-project)**
+**Option C: CLAUDE.md (per-project)**
 
 New project:
 ```bash


### PR DESCRIPTION
## Summary
- add CodeWhale install instructions using the existing skills/<name>/SKILL.md layout
- add CODEWHALE.md with trust, discovery, and contributor notes
- keep Claude Code plugin and CLAUDE.md install paths intact

## Notes
This is docs-only. CodeWhale already supports installing GitHub skill repos with `/skill install github:<owner>/<repo>`; this PR documents how to use this repo through that path.