### PR TITLE
Add headless mode fallback to Guideline 1 (Think Before Coding)

### DIFF
--- a/skills/karpathy-guidelines/SKILL.md
+++ b/skills/karpathy-guidelines/SKILL.md
@@ -20,6 +20,9 @@ Before implementing:
 - If a simpler approach exists, say so. Push back when warranted.
 - If something is unclear, stop. Name what's confusing. Ask.
 
+**In headless / non-interactive mode** (e.g. `claude -p`): asking is not possible.
+Instead: document assumptions inline, pick the most general interpretation, and proceed.
+
 ## 2. Simplicity First
 
 **Minimum code that solves the problem. Nothing speculative.**


### PR DESCRIPTION
## Summary

Guideline 1 currently tells the model to *stop and ask* when something is unclear. In headless / non-interactive mode (`claude -p`), there is no one to answer — this causes the model to either stall or produce questions into the void.

This adds a small note at the end of Guideline 1 that gives the model a clear fallback for headless runs: document assumptions inline, pick the most general interpretation, and proceed.

- No change to interactive mode behavior — the note is additive and mode-specific
- Guidelines 2, 3, and 4 are unaffected (they work fine headless as-is)

## Test plan

- [ ] Invoke the skill in interactive mode — behavior unchanged
- [ ] Invoke the skill via `claude -p` — model documents assumptions rather than stopping to ask

🤖 Generated with [Claude Code](https://claude.ai/claude-code)