### PR TITLE
Add Context Optimization principle (5th guideline)

### DIFF
--- a/.cursor/rules/karpathy-guidelines.mdc
+++ b/.cursor/rules/karpathy-guidelines.mdc
@@ -65,6 +65,19 @@ For multi-step tasks, state a brief plan:
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
+## 5. Context Optimization
+
+**Read what you need, not everything. Keep the window lean.**
+
+- Map before you read: list files, grep, or skim structure before opening anything in full.
+- Read in slices - use offset/limit and targeted search; don't load a 2000-line file for a 20-line answer.
+- Breadth before depth: sketch the whole task first, then go deep - and rebalance. Don't mine one branch to bedrock while sibling areas stay unread.
+- Don't re-read what you just wrote or already have in context. Trust the last edit.
+- Keep raw tool output (logs, large dumps) out of the window - summarize, extract, then discard.
+- Delegate to a subagent only when it has tools or reach you lack - not merely to "keep context clean."
+
+The test: Every file you open should change what you do next. If it won't, don't open it.
+
 ---
 
 **These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,19 @@ For multi-step tasks, state a brief plan:
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
+## 5. Context Optimization
+
+**Read what you need, not everything. Keep the window lean.**
+
+- Map before you read: list files, grep, or skim structure before opening anything in full.
+- Read in slices - use offset/limit and targeted search; don't load a 2000-line file for a 20-line answer.
+- Breadth before depth: sketch the whole task first, then go deep - and rebalance. Don't mine one branch to bedrock while sibling areas stay unread.
+- Don't re-read what you just wrote or already have in context. Trust the last edit.
+- Keep raw tool output (logs, large dumps) out of the window - summarize, extract, then discard.
+- Delegate to a subagent only when it has tools or reach you lack - not merely to "keep context clean."
+
+The test: Every file you open should change what you do next. If it won't, don't open it.
+
 ---
 
 **These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ From Andrej's post:
 
 ## The Solution
 
-Four principles in one file that directly address these issues:
+Five principles in one file that directly address these issues:
 
 | Principle | Addresses |
 |-----------|-----------|
@@ -28,8 +28,9 @@ Four principles in one file that directly address these issues:
 | **Simplicity First** | Overcomplication, bloated abstractions |
 | **Surgical Changes** | Orthogonal edits, touching code you shouldn't |
 | **Goal-Driven Execution** | Leverage through tests-first, verifiable success criteria |
+| **Context Optimization** | Context bloat, redundant reads, unfocused exploration |
 
-## The Four Principles in Detail
+## The Five Principles in Detail
 
 ### 1. Think Before Coding
 
@@ -95,6 +96,21 @@ For multi-step tasks, state a brief plan:
 ```
 
 Strong success criteria let the LLM loop independently. Weak criteria ("make it work") require constant clarification.
+
+### 5. Context Optimization
+
+**Read what you need, not everything. Keep the window lean.**
+
+Long, unfocused context degrades model attention and burns budget. Spend the window on signal:
+
+- **Map before you read** — list files, grep, or skim structure before opening anything in full
+- **Read in slices** — use offset/limit and targeted search; don't load a 2000-line file for a 20-line answer
+- **Breadth before depth** — sketch the whole task first, then go deep, and rebalance; don't mine one branch to bedrock while sibling areas stay unread
+- **Don't re-read** what you just wrote or already have in context — trust the last edit
+- **Keep raw output out** — summarize logs and large dumps, then discard them
+- **Delegate narrowly** — spawn a subagent only when it has tools or reach you lack, not just to "keep context clean"
+
+**The test:** Every file you open should change what you do next. If it won't, don't open it.
 
 ## Install
 

--- a/skills/karpathy-guidelines/SKILL.md
+++ b/skills/karpathy-guidelines/SKILL.md
@@ -65,3 +65,16 @@ For multi-step tasks, state a brief plan:
 ```
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+## 5. Context Optimization
+
+**Read what you need, not everything. Keep the window lean.**
+
+- Map before you read: list files, grep, or skim structure before opening anything in full.
+- Read in slices - use offset/limit and targeted search; don't load a 2000-line file for a 20-line answer.
+- Breadth before depth: sketch the whole task first, then go deep - and rebalance. Don't mine one branch to bedrock while sibling areas stay unread.
+- Don't re-read what you just wrote or already have in context. Trust the last edit.
+- Keep raw tool output (logs, large dumps) out of the window - summarize, extract, then discard.
+- Delegate to a subagent only when it has tools or reach you lack - not merely to "keep context clean."
+
+The test: Every file you open should change what you do next. If it won't, don't open it.


### PR DESCRIPTION
Adds a fifth principle — Context Optimization — to CLAUDE.md, the Cursor rule, and SKILL.md, and documents it in the README (table row + detailed section). Same terse imperative style as the existing four. Addresses context bloat, redundant whole-file reads, and unfocused exploration: map before reading, read in slices, breadth-before-depth with rebalancing, don't re-read, keep raw output out, delegate narrowly.