### PR TITLE
feat: add agent-split-strategy skill and example

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1,6 +1,6 @@
 # Examples
 
-Real-world code examples demonstrating the four principles. Each example shows what LLMs commonly do wrong and how to fix it.
+Real-world code examples demonstrating the principles. Each example shows what LLMs commonly do wrong and how to fix it.
 
 ---
 
@@ -492,6 +492,71 @@ def sort_scores(scores):
 
 # Verify: Test passes consistently
 ```
+
+---
+
+---
+
+## 5. Agent Split Strategy
+
+### Example: Implementing a new feature that spans backend and frontend
+
+**User Request:** "Add a user settings page with session management"
+
+**❌ What LLMs Do (Everything in One Pass)**
+
+```
+[Immediately starts writing code across all layers]
+
+Modified files:
+- packages/auth/src/sessions.ts          (+180 lines)
+- packages/auth/src/settings.ts          (+120 lines)
+- apps/api/src/routes/sessions.ts        (+90 lines)
+- apps/api/src/routes/settings.ts        (+110 lines)
+- apps/api/test/sessions.test.ts         (+220 lines)
+- apps/api/test/settings.test.ts         (+190 lines)
+- apps/web/src/pages/SettingsPage.tsx    (+300 lines)
+- apps/web/src/components/SessionList.tsx (+180 lines)
+
+Total: 1390 lines changed across 8 files in 3 packages
+```
+
+**Problems:**
+- Single diff is impossible to review coherently — reviewers lose context switching between domain logic, API, and UI
+- If the domain logic needs changes based on review, the UI work was done against the wrong contract
+- A bug in the migration blocks merging everything — including the unrelated UI
+- Rolling back requires reverting 8 files at once
+
+**✅ What Should Happen (Propose Split First)**
+
+```
+This task spans three independent layers. Proposed split:
+
+1. Domain logic (packages/auth)
+   - Session list query, revoke, bulk-revoke
+   - Settings read/write with env-lock support
+   Verify: unit tests pass, existing auth tests unchanged
+
+2. API routes (apps/api)
+   - GET /api/sessions, DELETE /api/sessions/:id
+   - PATCH /api/settings
+   Verify: integration tests pass against the domain from step 1
+
+3. Frontend UI (apps/web)
+   - SettingsPage, SessionList component
+   Verify: manual smoke — sessions list loads, revoke works
+
+Step 2 depends on step 1 being merged.
+Step 3 can start in parallel with step 2 once the API contract is agreed.
+
+Proceed with step 1?
+```
+
+**Why it works:**
+- Each PR is ~200–300 lines with a single reviewable concern
+- API contract is locked before UI is built — no rework
+- Domain logic can be reviewed and merged in hours; UI doesn't wait for that review cycle
+- A bug in step 1 doesn't block step 3 from being started
 
 ---
 

--- a/skills/agent-split-strategy/SKILL.md
+++ b/skills/agent-split-strategy/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: agent-split-strategy
+description: Guidelines for deciding when to split a task into multiple agents or PRs, and when not to. Use when receiving a large or multi-package task to avoid monolithic diffs that are hard to review and easy to break.
+license: MIT
+---
+
+# Agent Split Strategy
+
+LLMs tend to implement everything in one pass. For small tasks that's fine. For larger tasks it produces
+monolithic diffs that are hard to review, hard to roll back, and easy to break.
+
+**Tradeoff:** Splitting adds overhead. Don't split what you can do simply in one step.
+
+## When to split
+
+Split a task into sequential or parallel sub-tasks when **any** of these apply:
+
+- The task crosses more than ~3 package or module boundaries and the parts are **independently testable**.
+- A sub-task produces an artifact (schema, API contract, type definition) that another sub-task depends on.
+- The total diff would exceed ~400–600 lines — the point where reviewers lose context between files.
+- Backend and frontend changes are independent and neither blocks the other from being merged safely.
+
+## When NOT to split
+
+- The task is small and the sub-tasks are tightly coupled — splitting just adds handoff overhead.
+- The sub-tasks cannot be reviewed or merged independently without breaking the build.
+- You would spend more time coordinating than implementing.
+
+Three tightly coupled files changed together is better than three PRs that each leave the repo broken.
+
+## How to propose a split
+
+Before writing any code, state the split explicitly:
+
+```
+This task has three independent parts. Proposed split:
+
+1. DB migration + domain logic  →  verify: migration runs, unit tests pass
+2. API routes                   →  verify: integration tests pass, no regression
+3. Frontend UI                  →  verify: manual smoke, existing UI unchanged
+
+Part 2 depends on Part 1 being merged. Part 3 can start in parallel with Part 2.
+Proceed with Part 1?
+```
+
+Get alignment before starting. A split that the user doesn't know about is worse than no split.
+
+## Sequential vs parallel
+
+| Pattern | When to use |
+|---------|-------------|
+| **Sequential** | Sub-task B depends on A's output (schema, types, API shape) |
+| **Parallel** | Sub-tasks are fully independent — backend and docs, for example |
+
+When in doubt, sequential is safer. Parallel sub-tasks that share a file will produce conflicts.
+
+## Size heuristic
+
+| Diff size | Default action |
+|-----------|---------------|
+| < 200 lines | Implement in one pass |
+| 200–500 lines | Consider split if crossing package boundaries |
+| > 500 lines | Split unless it's a single coherent concern (e.g. a large migration with its tests) |
+
+These are soft ceilings. A 600-line change inside one package with full test coverage is fine. A 300-line change touching 5 packages with no tests is not.


### PR DESCRIPTION
## What this adds

### New skill: `skills/agent-split-strategy/`

The existing four principles cover *how* to write code, but not *how much* to take on in one pass. LLMs tend to implement everything in a single diff — even when the task spans multiple independent layers — producing monolithic PRs that are hard to review and easy to break.

This skill answers the question agents face before starting any non-trivial task: **split or not?**

It covers:
- **When to split**: >3 package boundaries, artifact dependency between sub-tasks, diff > ~400–600 lines, independent backend/frontend
- **When NOT to split**: tightly coupled sub-tasks, build would break between steps, coordination overhead exceeds implementation time
- **How to propose a split**: explicit plan with verify criteria before writing any code
- **Sequential vs parallel**: when each pattern applies
- **Size heuristic table**: soft ceilings by diff size

### New example in `EXAMPLES.md`

Adds a concrete before/after for "implement a feature spanning backend and frontend":
- ❌ LLM jumps in and produces 1390 lines across 8 files in 3 packages — unreviable, hard to roll back
- ✅ LLM proposes a three-step sequential split (domain logic → API routes → UI), gets alignment, then implements step 1

## Relationship to existing principles

This extends **Goal-Driven Execution** (principle 4): strong success criteria per sub-task let each part be independently verified before the next begins. It also reinforces **Think Before Coding** (principle 1) — planning the split *is* thinking before coding.

## Why it matters now

As LLMs are used for increasingly large features across codebases, the single-pass instinct is one of the most common sources of unreviable, hard-to-merge PRs. This gives agents a concrete decision framework to surface before they start.