### PR TITLE
Mark karpathy-guidelines skill as not user-invocable

### DIFF
--- a/skills/karpathy-guidelines/SKILL.md
+++ b/skills/karpathy-guidelines/SKILL.md
@@ -2,6 +2,7 @@
 name: karpathy-guidelines
 description: Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, surface assumptions, and define verifiable success criteria.
 license: MIT
+user-invocable: false
 ---
 
 # Karpathy Guidelines


### PR DESCRIPTION
## Summary
- Adds `user-invocable: false` to `skills/karpathy-guidelines/SKILL.md`'s frontmatter.

## Why
This skill is background behavioral guidance (four principles as reference text), not an actionable command — it takes no arguments and has no side effects. Since Claude Code merged custom commands into skills, this skill shows up in the `/` autocomplete menu as `/andrej-karpathy-skills:karpathy-guidelines` alongside real commands like `/deploy` or `/commit`. Invoking it manually just re-loads the same text Claude already loads automatically when relevant to the conversation, so it adds noise to the command list without giving users anything actionable to run.

Per Claude Code's [invocation control docs](https://code.claude.com/docs/en/skills#control-who-invokes-a-skill), `user-invocable: false` keeps Claude able to load the skill automatically while removing it from the user-facing slash-command menu — which matches how this skill is actually meant to be used.

## Test plan
- [ ] Confirm `/plugin` → skill still loads automatically when Claude judges it relevant to a coding task
- [ ] Confirm `/andrej-karpathy-skills:karpathy-guidelines` no longer appears in the `/` autocomplete list after reinstalling the plugin