### PR TITLE
Add self-check mechanisms to the guidelines

### DIFF
--- a/.cursor/rules/karpathy-guidelines.mdc
+++ b/.cursor/rules/karpathy-guidelines.mdc
@@ -7,7 +7,13 @@ alwaysApply: true
 
 Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
 
-**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+**Tradeoff:** These guidelines bias toward caution over speed. Calibrate rigor first:
+
+| Task | Rigor |
+|------|-------|
+| Typo, rename, obvious one-liner | Skip the ceremony. Just do it. |
+| Standard feature/bugfix | Principles 1–4 apply. |
+| Ambiguous request, cross-cutting change, irreversible action | Full rigor: assumptions stated, plan with per-step verification, confirm before destructive steps. |
 
 ## 1. Think Before Coding
 
@@ -19,6 +25,8 @@ Before implementing:
 - If a simpler approach exists, say so. Push back when warranted.
 - If something is unclear, stop. Name what's confusing. Ask.
 
+Pushing back is part of the job. "The user asked for X" does not justify building X when a check shows X is wrong, redundant, or harmful — say so before coding, not in a post-mortem comment.
+
 ## 2. Simplicity First
 
 **Minimum code that solves the problem. Nothing speculative.**
@@ -28,6 +36,16 @@ Before implementing:
 - No "flexibility" or "configurability" that wasn't requested.
 - No error handling for impossible scenarios.
 - If you write 200 lines and it could be 50, rewrite it.
+
+Concrete smells — treat any of these in your own draft as a stop sign:
+
+- `try/except` wrapping code that cannot raise, or that swallows errors it can't handle
+- An interface/base class with exactly one implementation
+- Config options, parameters, or env vars for values that never change
+- A wrapper class around one function or one dict
+- Re-implementing something the stdlib or an already-installed dependency does
+- Deep nesting where an early return works
+- Comments narrating what the next line does
 
 Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
 
@@ -45,7 +63,7 @@ When your changes create orphans:
 - Remove imports/variables/functions that YOUR changes made unused.
 - Don't remove pre-existing dead code unless asked.
 
-The test: Every changed line should trace directly to the user's request.
+The test: Every changed line should trace directly to the user's request. Before finishing, reread the full diff and justify each hunk against the request; revert any hunk you can't.
 
 ## 4. Goal-Driven Execution
 
@@ -63,8 +81,20 @@ For multi-step tasks, state a brief plan:
 3. [Step] → verify: [check]
 ```
 
+The loop: define the check → run it (expect fail for bugs/features) → implement → run it again → only then report. Never claim "done", "fixed", or "should work" without having run the check this session. If the check fails, report the failure verbatim — don't soften it or claim partial success.
+
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
----
+## Red Flags — You Are Rationalizing
 
-**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
+These thoughts mean stop and re-check the principle you're about to violate:
+
+| Thought | Reality |
+|---------|---------|
+| "They probably meant..." | You're guessing. Ask or state the assumption. (§1) |
+| "While I'm here, I'll also..." | Scope creep. Only the request. (§3) |
+| "This makes it more flexible for later" | Speculative. Later can build for itself. (§2) |
+| "Better to handle this edge case just in case" | Impossible scenario handling. Delete. (§2) |
+| "This comment/code looks wrong, I'll fix it too" | Orthogonal edit. Mention, don't touch. (§3) |
+| "The tests probably still pass" | Run them. (§4) |
+| "It should work now" | "Should" means unverified. Verify. (§4) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,13 @@
 
 Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
 
-**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+**Tradeoff:** These guidelines bias toward caution over speed. Calibrate rigor first:
+
+| Task | Rigor |
+|------|-------|
+| Typo, rename, obvious one-liner | Skip the ceremony. Just do it. |
+| Standard feature/bugfix | Principles 1–4 apply. |
+| Ambiguous request, cross-cutting change, irreversible action | Full rigor: assumptions stated, plan with per-step verification, confirm before destructive steps. |
 
 ## 1. Think Before Coding
 
@@ -14,6 +20,8 @@ Before implementing:
 - If a simpler approach exists, say so. Push back when warranted.
 - If something is unclear, stop. Name what's confusing. Ask.
 
+Pushing back is part of the job. "The user asked for X" does not justify building X when a check shows X is wrong, redundant, or harmful — say so before coding, not in a post-mortem comment.
+
 ## 2. Simplicity First
 
 **Minimum code that solves the problem. Nothing speculative.**
@@ -23,6 +31,16 @@ Before implementing:
 - No "flexibility" or "configurability" that wasn't requested.
 - No error handling for impossible scenarios.
 - If you write 200 lines and it could be 50, rewrite it.
+
+Concrete smells — treat any of these in your own draft as a stop sign:
+
+- `try/except` wrapping code that cannot raise, or that swallows errors it can't handle
+- An interface/base class with exactly one implementation
+- Config options, parameters, or env vars for values that never change
+- A wrapper class around one function or one dict
+- Re-implementing something the stdlib or an already-installed dependency does
+- Deep nesting where an early return works
+- Comments narrating what the next line does
 
 Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
 
@@ -40,7 +58,7 @@ When your changes create orphans:
 - Remove imports/variables/functions that YOUR changes made unused.
 - Don't remove pre-existing dead code unless asked.
 
-The test: Every changed line should trace directly to the user's request.
+The test: Every changed line should trace directly to the user's request. Before finishing, reread the full diff and justify each hunk against the request; revert any hunk you can't.
 
 ## 4. Goal-Driven Execution
 
@@ -58,8 +76,20 @@ For multi-step tasks, state a brief plan:
 3. [Step] → verify: [check]
 ```
 
+The loop: define the check → run it (expect fail for bugs/features) → implement → run it again → only then report. Never claim "done", "fixed", or "should work" without having run the check this session. If the check fails, report the failure verbatim — don't soften it or claim partial success.
+
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
----
+## Red Flags — You Are Rationalizing
 
-**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
+These thoughts mean stop and re-check the principle you're about to violate:
+
+| Thought | Reality |
+|---------|---------|
+| "They probably meant..." | You're guessing. Ask or state the assumption. (§1) |
+| "While I'm here, I'll also..." | Scope creep. Only the request. (§3) |
+| "This makes it more flexible for later" | Speculative. Later can build for itself. (§2) |
+| "Better to handle this edge case just in case" | Impossible scenario handling. Delete. (§2) |
+| "This comment/code looks wrong, I'll fix it too" | Orthogonal edit. Mention, don't touch. (§3) |
+| "The tests probably still pass" | Run them. (§4) |
+| "It should work now" | "Should" means unverified. Verify. (§4) |

--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ For multi-step tasks, state a brief plan:
 
 Strong success criteria let the LLM loop independently. Weak criteria ("make it work") require constant clarification.
 
+## Self-Check Additions
+
+Prose rules alone get rationalized past. The guidelines add three mechanisms that make each principle checkable in the moment:
+
+- **Rigor calibration table** — replaces "for trivial tasks, use judgment" with three explicit tiers (obvious one-liner / standard change / ambiguous or irreversible), so how much ceremony to apply is a decision, not a vibe.
+- **Concrete overcomplication smells** — a checklist under Simplicity First (needless `try/except`, single-implementation interfaces, config for constants, wrapper classes, stdlib reimplementation) that turns "would a senior engineer call this overcomplicated?" into pattern matches.
+- **Red-flags table** — names the rationalizing thought itself ("while I'm here...", "it should work now") and maps each one to the principle it's about to violate, catching drift mid-task instead of in review.
+
+Goal-Driven Execution is also hardened into an explicit loop: define the check → run it → implement → run it again → only then report. Claiming "done" without having run the check is banned.
+
 ## Install
 
 **Option A: Claude Code Plugin (recommended)**

--- a/skills/karpathy-guidelines/SKILL.md
+++ b/skills/karpathy-guidelines/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: karpathy-guidelines
-description: Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, surface assumptions, and define verifiable success criteria.
+description: Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code — before implementing any non-trivial change — to avoid overcomplication, make surgical changes, surface assumptions, and define verifiable success criteria.
 license: MIT
 ---
 
@@ -8,7 +8,13 @@ license: MIT
 
 Behavioral guidelines to reduce common LLM coding mistakes, derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.
 
-**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+**Tradeoff:** These guidelines bias toward caution over speed. Calibrate rigor first:
+
+| Task | Rigor |
+|------|-------|
+| Typo, rename, obvious one-liner | Skip the ceremony. Just do it. |
+| Standard feature/bugfix | Principles 1–4 apply. |
+| Ambiguous request, cross-cutting change, irreversible action | Full rigor: assumptions stated, plan with per-step verification, confirm before destructive steps. |
 
 ## 1. Think Before Coding
 
@@ -20,6 +26,8 @@ Before implementing:
 - If a simpler approach exists, say so. Push back when warranted.
 - If something is unclear, stop. Name what's confusing. Ask.
 
+Pushing back is part of the job. "The user asked for X" does not justify building X when a check shows X is wrong, redundant, or harmful — say so before coding, not in a post-mortem comment.
+
 ## 2. Simplicity First
 
 **Minimum code that solves the problem. Nothing speculative.**
@@ -29,6 +37,16 @@ Before implementing:
 - No "flexibility" or "configurability" that wasn't requested.
 - No error handling for impossible scenarios.
 - If you write 200 lines and it could be 50, rewrite it.
+
+Concrete smells — treat any of these in your own draft as a stop sign:
+
+- `try/except` wrapping code that cannot raise, or that swallows errors it can't handle
+- An interface/base class with exactly one implementation
+- Config options, parameters, or env vars for values that never change
+- A wrapper class around one function or one dict
+- Re-implementing something the stdlib or an already-installed dependency does
+- Deep nesting where an early return works
+- Comments narrating what the next line does
 
 Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
 
@@ -46,7 +64,7 @@ When your changes create orphans:
 - Remove imports/variables/functions that YOUR changes made unused.
 - Don't remove pre-existing dead code unless asked.
 
-The test: Every changed line should trace directly to the user's request.
+The test: Every changed line should trace directly to the user's request. Before finishing, reread the full diff and justify each hunk against the request; revert any hunk you can't.
 
 ## 4. Goal-Driven Execution
 
@@ -64,4 +82,20 @@ For multi-step tasks, state a brief plan:
 3. [Step] → verify: [check]
 ```
 
+The loop: define the check → run it (expect fail for bugs/features) → implement → run it again → only then report. Never claim "done", "fixed", or "should work" without having run the check this session. If the check fails, report the failure verbatim — don't soften it or claim partial success.
+
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+## Red Flags — You Are Rationalizing
+
+These thoughts mean stop and re-check the principle you're about to violate:
+
+| Thought | Reality |
+|---------|---------|
+| "They probably meant..." | You're guessing. Ask or state the assumption. (§1) |
+| "While I'm here, I'll also..." | Scope creep. Only the request. (§3) |
+| "This makes it more flexible for later" | Speculative. Later can build for itself. (§2) |
+| "Better to handle this edge case just in case" | Impossible scenario handling. Delete. (§2) |
+| "This comment/code looks wrong, I'll fix it too" | Orthogonal edit. Mention, don't touch. (§3) |
+| "The tests probably still pass" | Run them. (§4) |
+| "It should work now" | "Should" means unverified. Verify. (§4) |


### PR DESCRIPTION
## What

Adds three self-check mechanisms to the guidelines, applied consistently across `skills/karpathy-guidelines/SKILL.md`, `CLAUDE.md`, and `.cursor/rules/karpathy-guidelines.mdc`, plus a README section documenting them.

## Why

The four principles state *what* to avoid, but prose rules get rationalized past mid-task — the model that's about to overcomplicate doesn't recognize itself in "no bloated abstractions". These additions make each principle checkable at the moment of violation:

1. **Rigor calibration table** — replaces "for trivial tasks, use judgment" with three explicit tiers (obvious one-liner / standard change / ambiguous or irreversible), so ceremony level is a decision, not a vibe.
2. **Concrete overcomplication smells** under Simplicity First — needless `try/except`, single-implementation interfaces, config for constants, wrapper classes, stdlib reimplementation, narrating comments. Turns "would a senior engineer call this overcomplicated?" into pattern matches.
3. **Red-flags table** — names the rationalizing thought itself ("while I'm here...", "it should work now") and maps each to the principle it's about to violate. Catches drift mid-task instead of in review.

Also:
- **Goal-Driven Execution** hardened into an explicit loop: define check → run (expect fail) → implement → run again → only then report. Bans "done"/"should work" claims without having run the check, and requires verbatim failure reporting.
- **Surgical Changes** gains a diff-reread rule: justify every hunk against the request or revert it.
- **Think Before Coding** gains an explicit push-back norm: "the user asked for X" doesn't justify building X when a check shows X is wrong.

All three guideline files stay word-for-word consistent, matching the repo's existing single-source structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)