### PR TITLE
docs: point install commands at multica-ai (canonical repo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Strong success criteria let the LLM loop independently. Weak criteria ("make it 
 
 From within Claude Code, first add the marketplace:
 ```
-/plugin marketplace add forrestchang/andrej-karpathy-skills
+/plugin marketplace add multica-ai/andrej-karpathy-skills
 ```
 
 Then install the plugin:
@@ -116,13 +116,13 @@ This installs the guidelines as a Claude Code plugin, making the skill available
 
 New project:
 ```bash
-curl -o CLAUDE.md https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md
+curl -o CLAUDE.md https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/CLAUDE.md
 ```
 
 Existing project (append):
 ```bash
 echo "" >> CLAUDE.md
-curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
+curl https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
 ```
 
 ## Using with Cursor

--- a/README.zh.md
+++ b/README.zh.md
@@ -102,7 +102,7 @@ LLM 经常默默选择一种解释然后执行。这个原则强制明确推理�
 
 在 Claude Code 中，首先添加插件市场：
 ```
-/plugin marketplace add forrestchang/andrej-karpathy-skills
+/plugin marketplace add multica-ai/andrej-karpathy-skills
 ```
 
 然后安装插件：
@@ -116,13 +116,13 @@ LLM 经常默默选择一种解释然后执行。这个原则强制明确推理�
 
 新项目：
 ```bash
-curl -o CLAUDE.md https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md
+curl -o CLAUDE.md https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/CLAUDE.md
 ```
 
 已有项目（追加）：
 ```bash
 echo "" >> CLAUDE.md
-curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
+curl https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
 ```
 
 ## 在 Cursor 中使用


### PR DESCRIPTION
## What

The install instructions in `README.md` and `README.zh.md` still reference the **pre-transfer owner** `forrestchang/andrej-karpathy-skills`:

```
/plugin marketplace add forrestchang/andrej-karpathy-skills
curl -o CLAUDE.md https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md
curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
```

The repo now lives at **`multica-ai/andrej-karpathy-skills`**. This PR updates those three commands (in both the English and Chinese READMEs) to the canonical location.

## Why

To be upfront: the old commands **do currently work** — GitHub serves a transfer redirect from `forrestchang/…` to `multica-ai/…` (verified: `git ls-remote` succeeds and the raw URL returns `200`). So this is a doc-accuracy fix, not a broken-link fix.

It's still worth correcting because:
- The transfer redirect is **fragile** — it silently breaks if the old `forrestchang/andrej-karpathy-skills` name is ever recreated, at which point `marketplace add` and the `curl` commands would pull the wrong repo.
- Copy-pasteable install steps should name the repo's **canonical** home.

## Scope

- Only the three install-command owner references in each README changed (6 lines total); English and Chinese kept in sync.
- **Author attribution is untouched** — `author.name: "forrestchang"` in `plugin.json` / `marketplace.json` is left exactly as-is.
- The marketplace name (`karpathy-skills`) and plugin name (`andrej-karpathy-skills`) used by `/plugin install andrej-karpathy-skills@karpathy-skills` are unchanged and unaffected.
