### PR TITLE
Fix stale org references, add LICENSE, and enforce principle sync in CI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "karpathy-skills",
   "id": "karpathy-skills",
   "owner": {
-    "name": "forrestchang"
+    "name": "multica-ai"
   },
   "metadata": {
     "description": "Behavioral guidelines to reduce common LLM coding mistakes, derived from Andrej Karpathy's observations",
@@ -15,7 +15,7 @@
       "description": "Behavioral guidelines to reduce common LLM coding mistakes: Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven Execution",
       "version": "1.0.0",
       "author": {
-        "name": "forrestchang"
+        "name": "multica-ai"
       },
       "keywords": [
         "guidelines",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "description": "Behavioral guidelines to reduce common LLM coding mistakes, derived from Andrej Karpathy's observations on LLM coding pitfalls",
   "version": "1.0.0",
   "author": {
-    "name": "forrestchang"
+    "name": "multica-ai"
   },
   "license": "MIT",
   "keywords": ["guidelines", "best-practices", "coding", "karpathy"],

--- a/.github/workflows/sync-check.yml
+++ b/.github/workflows/sync-check.yml
@@ -1,0 +1,51 @@
+name: Sync check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  principles-in-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check the four principles are identical across all copies
+        run: |
+          python3 - <<'PY'
+          import sys, pathlib
+
+          FILES = [
+              "CLAUDE.md",
+              ".cursor/rules/karpathy-guidelines.mdc",
+              "skills/karpathy-guidelines/SKILL.md",
+          ]
+          START = "## 1. Think Before Coding"
+
+          def extract(path):
+              text = pathlib.Path(path).read_text()
+              if START not in text:
+                  print(f"::error file={path}::missing section '{START}'")
+                  sys.exit(1)
+              body = text.split(START, 1)[1]
+              body = body.split("\n---", 1)[0]  # drop the trailing footer, if any
+              return (START + body).strip()
+
+          reference_path = FILES[0]
+          reference = extract(reference_path)
+
+          failed = False
+          for path in FILES[1:]:
+              if extract(path) != reference:
+                  print(
+                      f"::error file={path}::principle text differs from "
+                      f"{reference_path}. Update all copies together "
+                      f"(see CURSOR.md)."
+                  )
+                  failed = True
+
+          if failed:
+              sys.exit(1)
+          print(f"All {len(FILES)} copies of the principle text are in sync.")
+          PY

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jiayuan Zhang and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Strong success criteria let the LLM loop independently. Weak criteria ("make it 
 
 From within Claude Code, first add the marketplace:
 ```
-/plugin marketplace add forrestchang/andrej-karpathy-skills
+/plugin marketplace add multica-ai/andrej-karpathy-skills
 ```
 
 Then install the plugin:
@@ -116,13 +116,13 @@ This installs the guidelines as a Claude Code plugin, making the skill available
 
 New project:
 ```bash
-curl -o CLAUDE.md https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md
+curl --fail -o CLAUDE.md https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/CLAUDE.md
 ```
 
 Existing project (append):
 ```bash
 echo "" >> CLAUDE.md
-curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
+curl --fail https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
 ```
 
 ## Using with Cursor

--- a/README.zh.md
+++ b/README.zh.md
@@ -102,7 +102,7 @@ LLM 经常默默选择一种解释然后执行。这个原则强制明确推理�
 
 在 Claude Code 中，首先添加插件市场：
 ```
-/plugin marketplace add forrestchang/andrej-karpathy-skills
+/plugin marketplace add multica-ai/andrej-karpathy-skills
 ```
 
 然后安装插件：
@@ -116,13 +116,13 @@ LLM 经常默默选择一种解释然后执行。这个原则强制明确推理�
 
 新项目：
 ```bash
-curl -o CLAUDE.md https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md
+curl --fail -o CLAUDE.md https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/CLAUDE.md
 ```
 
 已有项目（追加）：
 ```bash
 echo "" >> CLAUDE.md
-curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
+curl --fail https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
 ```
 
 ## 在 Cursor 中使用


### PR DESCRIPTION
Four small packaging fixes. No changes to the guidance text itself.

### 1. Stale `forrestchang` references (9 occurrences)

The repo now lives at `multica-ai`, but install instructions and plugin metadata still pointed at the old owner:

| File | Occurrences |
|---|---|
| `README.md` / `README.zh.md` | marketplace command + 2 curl URLs each |
| `.claude-plugin/plugin.json` | `author.name` |
| `.claude-plugin/marketplace.json` | `owner.name`, `plugins[0].author.name` |

These currently resolve **only** via GitHub's rename redirect (`github.com/forrestchang/...` returns 301). That redirect stops working the moment anyone registers a repo at the old path, so the install instructions are one namespace-squat away from breaking.

### 2. Missing `LICENSE`

MIT is declared in `plugin.json`, the `SKILL.md` frontmatter, and the README, but there was no `LICENSE` file. For a repo designed to be copied into other projects, that's worth having explicit.

### 3. `curl --fail` on install commands

Without `--fail`, curl exits `0` on an HTTP error and writes the error page into the user's `CLAUDE.md`. The append variant (`curl ... >> CLAUDE.md`) silently corrupts an existing file. Verified: `--fail` now exits non-zero (56) on a 404.

### 4. CI check that the principles stay in sync

The four principles are duplicated across `CLAUDE.md`, `.cursor/rules/karpathy-guidelines.mdc`, and `skills/karpathy-guidelines/SKILL.md`. `CURSOR.md` asks contributors to keep these aligned by hand; this adds a check that enforces it.

The three copies are currently identical, so the check passes on `main` as-is. I verified it also *fails* correctly by injecting a one-word change into `SKILL.md`, then passes again once reverted — a check that can't fail isn't worth adding.

---

### Two things worth a maintainer's call

**`LICENSE` copyright holder.** I used `Copyright (c) 2026 Jiayuan Zhang and contributors`, since copyright vests in the author and doesn't transfer with a repo move (initial commit is 2026-01-27). Happy to change it to `multica-ai` if that's the intent.

**Author fields vs. URLs.** Six of the nine replacements are repo paths — unambiguous fixes. The other three (`author.name`, `owner.name`) are attribution rather than routing, and changing them reassigns credit from the original author to the org. I changed them for consistency, but they're easy to revert independently if you'd rather keep the personal attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)